### PR TITLE
comment out !html_name for nodes that are already merged

### DIFF
--- a/anhang/anhang/xhdi/xhdi_de.ui
+++ b/anhang/anhang/xhdi/xhdi_de.ui
@@ -3,6 +3,7 @@
 
 
 !begin_node XHDI - eXtended HardDisk Interface (Version 1.30)
+!html_name xhdi
 !label XHDI
 
 Wie unschwer am Namen zu erkennen ist, soll die XHDI-Spezifikation die
@@ -1057,7 +1058,7 @@ XHDI-Terminologie
 
 
 !begin_node XHMediumChanged
-!html_name XHMediumChanged
+#!html_name XHMediumChanged
 
 (!begin_liste) [Beschreibung]
 

--- a/anhang/typedefs.u
+++ b/anhang/typedefs.u
@@ -15,7 +15,7 @@ DSPBLOCK     !! DTA          !! EVNT         !! fcookie      !! FILEPTR
 FILESYS      !! fix31        !! FNTS_ITEM    !! FONT_HDR     !! fs_descr
 GEM_MUPB     !! GRECT        !! HDFUNCS      !! HNDL_OBJ     !! ICONBLK
 IOREC        !! KBDVBASE     !! KEYTAB       !! LBOX_ITEM    !! LINE
-ltchars      !! MAPTAB       !! MCB          !! (!link [MD][Memory Descriptor (MD) in TOS]) !! MEDIA_SIZE
+ltchars      !! MAPTAB       !! MCB          !! (!link [MD][Memory Descriptor (MD!) in TOS]) !! MEDIA_SIZE
 MEDIA_TYPE   !! MENU         !! META_DRVINFO !! META_INFO_1  !! META_INFO_2
 META_HEADER  !! MFDB         !! MFORM        !! MN_SET       !! MOUSE
 MPB          !! MRETS        !! mutimbuf     !! OBJECT       !! OHEADER
@@ -285,7 +285,7 @@ wish to do so can therefore release memory-resident programs (or also
 parts of them) subsequently.
 
 See also:
-GEMDOS  ~ MagiC ~  (!link [MD][Memory Descriptor (MD) in TOS]) ~
+GEMDOS  ~ MagiC ~  (!link [MD][Memory Descriptor (MD!) in TOS]) ~
 Memory management
 !end_node
 
@@ -608,7 +608,7 @@ DSPBLOCK     !! DTA          !! EVNT         !! fcookie      !! FILEPTR
 FILESYS      !! fix31        !! FNTS_ITEM    !! FONT_HDR     !! fs_descr
 GEM_MUPB     !! GRECT        !! HDFUNCS      !! HNDL_OBJ     !! ICONBLK
 IOREC        !! KBDVBASE     !! KEYTAB       !! LBOX_ITEM    !! LINE
-ltchars      !! MAPTAB       !! MCB          !! (!link [MD][Memory-Deskriptor (MD)]) !! MEDIA_SIZE
+ltchars      !! MAPTAB       !! MCB          !! (!link [MD][Memory-Deskriptor (MD!)]) !! MEDIA_SIZE
 MEDIA_TYPE   !! MENU         !! META_DRVINFO !! META_INFO_1  !! META_INFO_2
 META_HEADER  !! MFDB         !! MFORM        !! MN_SET       !! MOUSE
 MPB          !! MRETS        !! mutimbuf     !! OBJECT       !! OHEADER
@@ -878,7 +878,7 @@ MCBs ÅberprÅft).  Wer mîchte, kann also speicherresidente Programme (oder
 auch Teile davon) nachtrÑglich freigeben.
 
 Querverweis:
-GEMDOS  ~ MagiC ~  (!link [MD][Memory-Deskriptor (MD)]) ~
+GEMDOS  ~ MagiC ~  (!link [MD][Memory-Deskriptor (MD!)]) ~
 Speicherverwaltung
 !end_node
 

--- a/bios/cookie/description/LDGE.ui
+++ b/bios/cookie/description/LDGE.ui
@@ -1,6 +1,6 @@
 !iflang [english]
 
-!begin_node Cookie, LDGE
+!begin_node Cookie, LDGM
 
 (!B)GEM Dynamical Libraries(!b) (LDG)
 
@@ -8,7 +8,7 @@
 
 !else
 
-!begin_node Cookie, LDGE
+!begin_node Cookie, LDGM
 
 (!B)GEM Dynamical Libraries(!b) (LDG)
 

--- a/bios/cookie/description/PCI_.ui
+++ b/bios/cookie/description/PCI_.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node Cookie, PCI_
-!html_name Cookie_PCI_
+#!html_name Cookie_PCI_
 
 (!B)PCI-(!nolink [BIOS])(!b)
 
@@ -18,7 +18,7 @@ See also: PCI-BIOS ~ (!link [Cookie XPCI][Cookie, XPCI])
 !else
 
 !begin_node Cookie, PCI_
-!html_name Cookie_PCI_
+#!html_name Cookie_PCI_
 
 (!B)PCI-(!nolink [BIOS])(!b)
 

--- a/bios/cookie/description/XPCI.ui
+++ b/bios/cookie/description/XPCI.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node Cookie, XPCI
-!html_name Cookie_XPCI
+#!html_name Cookie_XPCI
 
 (!B)X(!nolink [BIOS]) functions for PCI-(!nolink [BIOS])(!b)
 
@@ -11,7 +11,7 @@ See also: PCI-BIOS ~ (!link [Cookie PCI_][Cookie, PCI_])
 !else
 
 !begin_node Cookie, XPCI
-!html_name Cookie_XPCI
+#!html_name Cookie_XPCI
 
 (!B)X(!nolink [BIOS]) functions for PCI-(!nolink [BIOS])(!b)
 

--- a/bios/cookie/description/_MCF.ui
+++ b/bios/cookie/description/_MCF.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node Cookie, _MCF
-!html_name Cookie_MCF
+#!html_name Cookie_MCF
 
 
 (!B)ColdFire features(!b)
@@ -83,7 +83,7 @@ MCF_DEBUG_D_PLUS_PST !! 15
 !else
 
 !begin_node Cookie, _MCF
-!html_name Cookie_MCF
+#!html_name Cookie_MCF
 
 
 (!B)ColdFire features(!b)

--- a/bios/cookie/description/_PCI.ui
+++ b/bios/cookie/description/_PCI.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node Cookie, _PCI
-!html_name Cookie__PCI
+#!html_name Cookie__PCI
 
 (!B)PCI-(!nolink [BIOS])(!b)
 
@@ -20,7 +20,7 @@ See also: PCI-BIOS ~ (!link [Cookie XPCI][Cookie, XPCI])
 
 !begin_node Cookie, _PCI
 
-!html_name Cookie__PCI
+#!html_name Cookie__PCI
 
 (!B)PCI-(!nolink [BIOS])(!b)
 

--- a/bios/function/rwabs.u
+++ b/bios/function/rwabs.u
@@ -42,10 +42,10 @@ For this, a hard disk driver that is compatible with AHDI 3.0 is required.
 In (!I)recnr(!i) the starting sector on the drive will be specified.
 (!I)lrecno(!i) will be used only if (!I)recnr(!i) has the value -1, 
 and an AHDI 3.0-compatible
-(!link [hard disk driver][XHDI - eXtended HardDisk Interface (Version 1.30)])
+(!link [hard disk driver][XHDI - eXtended HardDisk Interface (Version 1.30!)])
 is available.
 
-!item [(!nolink [Return]) value:]
+!item [Return value:]
 The function returns 0 if the access was successful, otherwise a negative
 number.
 
@@ -125,8 +125,8 @@ Hierzu ist ein Festplattentreiber notwendig, der zu AHDI 3.0 kompatibel ist.
 !end_xlist
 Es werden (!I)cnt(!i) Zeichen vom Puffer (!I)buff(!i) Åbertragen. In recnr
 wird der Startsektor auf dem Laufwerk angegeben. (!I)lrecno(!i) wird nur
-benutzt, wenn (!I)recnr(!i) den Wert -1 besitzt, und ein AHDI-3.0
-kompatibler (!link [Festplattentreiber][XHDI - eXtended HardDisk Interface (Version 1.30)]) zur VerfÅgung steht.
+benutzt, wenn (!I)recnr(!i) den Wert -1 besitzt, und ein AHDI!-3.0
+kompatibler (!link [Festplattentreiber][XHDI - eXtended HardDisk Interface (Version 1.30!)]) zur VerfÅgung steht.
 !item [Ergebnis:]
 Die Funktion liefert als Ergebnis eine 0, wenn der Zugriff erfolgreich war,
 ansonsten eine negative Zahl.

--- a/gem/aes/appl_/_appl_yield.ui
+++ b/gem/aes/appl_/_appl_yield.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node _appl_yield
-!html_name _appl_yield
+#!html_name _appl_yield
 (!begin_liste) [Availability]
 !item [Name:]
 ØApplication yieldÆ - Force (!nolink [AES]) process-switch.
@@ -32,7 +32,7 @@ Application library
 
 
 !begin_node Bindings for _appl_yield
-!html_name Bindings_for__appl_yield
+#!html_name Bindings_for__appl_yield
 !ignore_index
 (!begin_liste) [GEM-Arrays]
 !item [C:]
@@ -82,7 +82,7 @@ Die Funktion ist verfÅgbar seit TOS 1.0, KAOS und MagiC seit Version 1.0.
 
 
 !begin_node Bindings fÅr _appl_yield
-!html_name Bindings_for__appl_yield
+#!html_name Bindings_for__appl_yield
 !ignore_index
 (!begin_liste) [GEM-Arrays]
 !item [C:]

--- a/gem/aes/appl_/appl_control.ui
+++ b/gem/aes/appl_/appl_control.ui
@@ -3,7 +3,7 @@
 !iflang [english]
 
 !begin_node appl_control
-!html_name appl_control
+#!html_name appl_control
 (!begin_liste) [Availability]
 !item [Name:]
 ØApplication (!nolink [control])Æ - Targeted (!nolink [control]) of applications.
@@ -39,7 +39,7 @@ Reserved for (!nolink [N.AES])
 OAESis internal mode
 
 !label APC_KILL
-!item [APC_KILL  (1)]
+!item [APC_KILL (1)]
  (!nl)
 OAESis internal mode
 
@@ -86,7 +86,7 @@ For (!I)ap_cout(!i) a pointer to an integer is to be passed
 (!nolink [N.AES]) here deposits the application parameters in the form of a
 bitmask:
 
-!begin_xlist  [APCI_]
+!begin_xlist  [APCI_HIDD]
 !label APCI_HIDDEN
 !item [APCI_HIDDEN (1)]  Bit 0 is set if the application is faded out
 
@@ -210,7 +210,7 @@ Application library
 
 
 !begin_node Bindings for appl_control
-!html_name Bindings_for_appl_control
+#!html_name Bindings_for_appl_control
 !ignore_index
 (!begin_liste) [GEM-Arrays]
 !item [C:]
@@ -249,7 +249,7 @@ int_out !! int_out[0] !! ap_creturn
 !else
 
 !begin_node appl_control
-!html_name appl_control
+#!html_name appl_control
 
 (!begin_liste) [Beschreibung]
 !item [Name:]
@@ -272,7 +272,7 @@ werden soll.
 !item [ap_cwhat]
 Die Art der Steuerung:
 
-!begin_xlist [~~~]
+!begin_xlist [APC_TOPNEXT ]
 
 !item [0 bis 9]
  (!nl)
@@ -327,7 +327,7 @@ Abfragen von Applikations!-parametern der An!-wendung (!I)ap_cid(!i). Wird fÅr (
 FÅr (!I)ap_cout(!i) ist ein Zeiger auf einen Integer zu Åbergeben. N.AES hinterlegt hier
 die Applikationsparameter in Form einer  Bitmaske:
 
-!begin_xlist  [APCI_]
+!begin_xlist  [APCI_HIDD]
 !label APCI_HIDDEN
 !item [APCI_HIDDEN (1)]
 Bit 0 ist gesetzt, wenn die Applikation aus!-ge!-blendet ist.
@@ -453,7 +453,7 @@ nachprÅfbar.
 
 
 !begin_node Bindings fÅr appl_control
-!html_name Bindings_for_appl_control
+#!html_name Bindings_for_appl_control
 !ignore_index
 (!begin_liste) [GEM-Arrays]
 !item [C:]

--- a/gem/aes/appl_/appl_get_cicon.ui
+++ b/gem/aes/appl_/appl_get_cicon.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node appl_getcicon
-!html_name appl_getcicon
+#!html_name appl_getcicon
 
 (!begin_liste) [Availability]
 !item [Name:]
@@ -120,7 +120,7 @@ Application library
 
 
 !begin_node Bindings for appl_getcicon
-!html_name Bindings for appl_getcicon
+#!html_name Bindings for appl_getcicon
 
 !ignore_index
 (!begin_liste) [GEM-Arrays]
@@ -173,7 +173,7 @@ addr_out  !! addr_out[0]!! cicon_data
 !else
 
 !begin_node appl_getcicon
-!html_name appl_getcicon
+#!html_name appl_getcicon
 
 (!begin_liste) [Beschreibung]
 !item [Name:]
@@ -294,7 +294,7 @@ Seit MyAES 0.96 beta1
 
 
 !begin_node Bindings fÅr appl_getcicon
-!html_name Bindings for appl_getcicon
+#!html_name Bindings for appl_getcicon
 
 !ignore_index
 (!begin_liste) [GEM-Arrays]

--- a/gem/aes/appl_/appl_yield.ui
+++ b/gem/aes/appl_/appl_yield.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node appl_yield
-!html_name appl_yield
+#!html_name appl_yield
 (!begin_liste) [Availability]
 !item [Name:]
 ØApplication yieldÆ - Force (!nolink [AES]) process-switch.
@@ -34,7 +34,7 @@ Application library
 
 
 !begin_node Bindings for appl_yield
-!html_name Bindings_for_appl_yield
+#!html_name Bindings_for_appl_yield
 !ignore_index
 (!begin_liste) [GEM-Arrays]
 !item [C:]
@@ -64,7 +64,7 @@ int_out !! int_out[0] !! Return value
 !else
 
 !begin_node appl_yield
-!html_name appl_yield
+#!html_name appl_yield
 (!begin_liste) [Beschreibung]
 !item [Name:]
 ØApplication yieldÆ - Prozeûwechsel erzwingen
@@ -95,7 +95,7 @@ Die Funktion steht nur unter PC-GEM, Geneva, sowie MagiC
 
 
 !begin_node Bindings fÅr appl_yield
-!html_name Bindings_for_appl_yield
+#!html_name Bindings_for_appl_yield
 !ignore_index
 (!begin_liste) [GEM-Arrays]
 !item [C:]

--- a/gem/aes/edit_/edit_set_format.ui
+++ b/gem/aes/edit_/edit_set_format.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node edit_set_format
-!html_name edit_set_format
+#!html_name edit_set_format
 
 (!begin_liste) [Availability]
 !item [Name:]
@@ -56,7 +56,7 @@ Editable object functions
 
 
 !begin_node Bindings for edit_set_format
-!html_name Bindings_for_edit_set_format
+#!html_name Bindings_for_edit_set_format
 
 !ignore_index
 
@@ -103,7 +103,7 @@ addr_in   !! addr_in[0] !! tree
 !else
 
 !begin_node edit_set_format
-!html_name edit_set_format
+#!html_name edit_set_format
 
 (!begin_liste) [Beschreibung]
 !item [Name:]
@@ -156,7 +156,7 @@ Editobjekt-Funktionen
 
 
 !begin_node Bindings fÅr edit_set_format
-!html_name Bindings_for_edit_set_format
+#!html_name Bindings_for_edit_set_format
 
 !ignore_index
 

--- a/gem/aes/lbox_/lbox_ascroll_to.ui
+++ b/gem/aes/lbox_/lbox_ascroll_to.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node lbox_ascroll_to
-!html_name lbox_ascroll_to
+#!html_name lbox_ascroll_to
 
 !label lbox_scroll_to
 
@@ -58,7 +58,7 @@ List boxes
 
 
 !begin_node Bindings for lbox_ascroll_to
-!html_name Bindings_for_lbox_ascroll_to
+#!html_name Bindings_for_lbox_ascroll_to
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]
@@ -114,7 +114,7 @@ int_in+2  !! int_in[1]  !! first
 !else
 
 !begin_node lbox_ascroll_to
-!html_name lbox_ascroll_to
+#!html_name lbox_ascroll_to
 
 !label lbox_scroll_to
 
@@ -170,7 +170,7 @@ Listboxen
 
 
 !begin_node Bindings fÅr lbox_ascroll_to
-!html_name Bindings_for_lbox_ascroll_to
+#!html_name Bindings_for_lbox_ascroll_to
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]

--- a/gem/aes/rsrc_/rsrc_gaddr.ui
+++ b/gem/aes/rsrc_/rsrc_gaddr.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node rsrc_gaddr
-!html_name rsrc_gaddr
+#!html_name rsrc_gaddr
 
 (!begin_liste) [Availability]
 
@@ -62,7 +62,7 @@ Parameter  !! Meaning
 
 (!B)Note:(!b) If one wants to search for a text pointer within a TEDINFO
 structure, for instance, then one must (!I)not(!i) pass the index of the
-associated object, but the index of the (!nolink [TEDINFO]) structure. The
+associated object, but the index of the TEDINFO structure. The
 same applies in essence to other codings.
 
 !item [(!nolink [Return]) value:]
@@ -82,7 +82,7 @@ Resource library
 
 
 !begin_node Bindings for rsrc_gaddr
-!html_name Bindings_for_rsrc_gaddr
+#!html_name Bindings_for_rsrc_gaddr
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]
@@ -130,7 +130,7 @@ addr_out  !! addr_out[0] !! gaddr
 !else
 
 !begin_node rsrc_gaddr
-!html_name rsrc_gaddr
+#!html_name rsrc_gaddr
 
 (!begin_liste) [Beschreibung]
 
@@ -192,7 +192,7 @@ gaddr !! Adresse der gewÅnschten Struktur
 
 (!B)Hinweis:(!b) Wenn beispielsweise der Textzeiger innerhalb einer
 TEDINFO-Struktur gesucht werden soll, so muû nicht die Nummer des
-zugehîrigen Objektes, sondern die Nummer der (!nolink [TEDINFO])-Struktur Åbergeben
+zugehîrigen Objektes, sondern die Nummer der TEDINFO-Struktur Åbergeben
 werden. FÅr andere Codierungen gilt i.w. das gleiche.
 
 !item [Ergebnis:]
@@ -212,7 +212,7 @@ All (!nolink [AES]) versions.
 
 
 !begin_node Bindings fÅr rsrc_gaddr
-!html_name Bindings_for_rsrc_gaddr
+#!html_name Bindings_for_rsrc_gaddr
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]

--- a/gem/aes/scrp_/scrp_clear.ui
+++ b/gem/aes/scrp_/scrp_clear.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node scrp_clear
-!html_name scrp_clear
+#!html_name scrp_clear
 
 (!begin_liste) [Availability]
 
@@ -39,7 +39,7 @@ Data exchange via the GEM clipboard
 
 
 !begin_node Bindings for scrp_clear
-!html_name Bindings_for_scrp_clear
+#!html_name Bindings_for_scrp_clear
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]
@@ -74,7 +74,7 @@ int_out   !! int_out[0] !! Return value
 !else
 
 !begin_node scrp_clear
-!html_name scrp_clear
+#!html_name scrp_clear
 
 (!begin_liste) [Beschreibung]
 
@@ -113,7 +113,7 @@ Nicht vorhanden in ViewMAX.
 
 
 !begin_node Bindings fÅr scrp_clear
-!html_name Bindings_for_scrp_clear
+#!html_name Bindings_for_scrp_clear
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]

--- a/gem/aes/structures/WINFRAME_HANDLER.ui
+++ b/gem/aes/structures/WINFRAME_HANDLER.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node WINFRAME_HANDLER
-!html_name WINFRAME_HANDLER
+#!html_name WINFRAME_HANDLER
 
 Passing structure for linking in
 
@@ -29,7 +29,7 @@ sys_set_winframe_manager ~ WININFO ~ WINFRAME_SETTINGS
 !else
 
 !begin_node WINFRAME_HANDLER
-!html_name WINFRAME_HANDLER
+#!html_name WINFRAME_HANDLER
 
 šbergabe-Struktur zum Einklinken
 

--- a/gem/aes/structures/WINFRAME_SETTINGS.ui
+++ b/gem/aes/structures/WINFRAME_SETTINGS.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node WINFRAME_SETTINGS
-!html_name WINFRAME_SETTINGS
+#!html_name WINFRAME_SETTINGS
 
 Passing structure for global window settings
 
@@ -24,7 +24,7 @@ sys_set_winframe_manager ~ WINFRAME_HANDLER ~ WININFO
 !else
 
 !begin_node WINFRAME_SETTINGS
-!html_name WINFRAME_SETTINGS
+#!html_name WINFRAME_SETTINGS
 
 
 !begin_verbatim

--- a/gem/aes/structures/WININFO.ui
+++ b/gem/aes/structures/WININFO.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node WININFO
-!html_name WININFO
+#!html_name WININFO
 
 WINDOW-structure for MagiC-kernel
 
@@ -54,7 +54,7 @@ sys_set_winframe_manager ~ WINFRAME_HANDLER ~ WINFRAME_SETTINGS
 !else
 
 !begin_node WININFO
-!html_name WININFO
+#!html_name WININFO
 
 WINDOW-Struktur fÅr MagiC-Kernel
 

--- a/gem/aes/wind_/sys_set_winframe_manager.ui
+++ b/gem/aes/wind_/sys_set_winframe_manager.ui
@@ -3,7 +3,7 @@
 !iflang [english]
 
 !begin_node sys_set_winframe_manager
-!html_name sys_set_winframe_manager
+#!html_name sys_set_winframe_manager
 
 (!begin_liste) [Availability]
 
@@ -39,7 +39,7 @@ Window library
 
 
 !begin_node Bindings for sys_set_winframe_manager
-!html_name Bindings_for_sys_set_winframe_manager
+#!html_name Bindings_for_sys_set_winframe_manager
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]
@@ -90,7 +90,7 @@ addr_out  !! addr_out[0] !! set
 !else
 
 !begin_node sys_set_winframe_manager
-!html_name sys_set_winframe_manager
+#!html_name sys_set_winframe_manager
 
 (!begin_liste) [Beschreibung]
 
@@ -124,7 +124,7 @@ Fensterverwaltung
 
 
 !begin_node Bindings fÅr sys_set_winframe_manager
-!html_name Bindings_for_sys_set_winframe_manager
+#!html_name Bindings_for_sys_set_winframe_manager
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]

--- a/gem/aes/wind_/wind_set.ui
+++ b/gem/aes/wind_/wind_set.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node wind_set
-!html_name wind_set
+#!html_name wind_set
 (!begin_liste) [Availability]
 
 !item [Name:]
@@ -622,7 +622,7 @@ Window library
 
 
 !begin_node wind_set and PC-GEM
-!html_name wind_set_and_PC_GEM
+#!html_name wind_set_and_PC_GEM
 (!B)As of PC-(!nolink [GEM]) Version 2.0 the following apply:(!b)
 
 !label WF_ATTRB, wind_set
@@ -651,7 +651,7 @@ Height of the window
 
 
 !begin_node Bindings for wind_set
-!html_name Bindings_for_wind_set
+#!html_name Bindings_for_wind_set
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]
@@ -702,7 +702,7 @@ int_out   !! int_out[0] !! Return value
 !else
 
 !begin_node wind_set
-!html_name wind_set
+#!html_name wind_set
 (!begin_liste) [Beschreibung]
 
 !item [Name:]
@@ -1277,7 +1277,7 @@ Fensterverwaltung
 
 
 !begin_node wind_set und PC-GEM
-!html_name wind_set_and_PC_GEM
+#!html_name wind_set_and_PC_GEM
 
 (!B)Ab PC-(!nolink [GEM]) Version 2.0 gilt:(!b)
 
@@ -1306,7 +1306,7 @@ Hîhe des Fensters
 
 
 !begin_node Bindings fÅr wind_set
-!html_name Bindings_for_wind_set
+#!html_name Bindings_for_wind_set
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]

--- a/gem/aes/wind_/wind_set/WF_TOPMOST.ui
+++ b/gem/aes/wind_/wind_set/WF_TOPMOST.ui
@@ -1,7 +1,8 @@
 !iflang [english]
 
 !begin_node WF_TOPMOST, wind_set
-!html_name WF_TOPMOST_wind_set
+!label WF_TOPMOST, wind_get
+#!html_name WF_TOPMOST_wind_set
 
 A class of windows that will always 'float' ontop of classical windows.
 One key feature of windows in any (!nolink [WF_TOPMOST]) state is that they do not
@@ -54,7 +55,8 @@ and no application handling is necessary.
 !else
 
 !begin_node WF_TOPMOST, wind_set
-!html_name WF_TOPMOST_wind_set
+!label WF_TOPMOST, wind_get
+#!html_name WF_TOPMOST_wind_set
 
 A class of windows that will always 'float' ontop of classical windows.
 One key feature of windows in any (!nolink [WF_TOPMOST]) state is that they do not

--- a/gem/vdi/attribut/fill/filltypes.ui
+++ b/gem/vdi/attribut/fill/filltypes.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node Graphical overview of fill-type and pattern index
-!html_name Graphical_overview_of_fill_type_and_pattern_index
+#!html_name Graphical_overview_of_fill_type_and_pattern_index
 
 The following illustration shows the possible combinations of the
 fill-type and the pattern index. The first number here specifies the
@@ -29,7 +29,7 @@ See also: vsf_interior ~  vsf_style
 
 
 !begin_node Description of the VDI writing modes
-!html_name Description_of_the_VDI_writing_modes
+#!html_name Description_of_the_VDI_writing_modes
 
 !label Replace mode
 (!B)Replace:(!b) In this mode the (!nolink [VDI]) overwrites the background
@@ -113,7 +113,7 @@ See also: vswr_mode
 !else
 
 !begin_node Grafische öbersicht von FÅlltyp und Musterindex
-!html_name Graphical_overview_of_fill_type_and_pattern_index
+#!html_name Graphical_overview_of_fill_type_and_pattern_index
 
 Die folgende Abbildung zeigt die mîglichen Kombinationen von FÅlltyp und
 Musterindex. Die erste Ziffer gibt dabei den FÅlltyp, die zweite den Index
@@ -139,7 +139,7 @@ Querverweis: vsf_interior ~  vsf_style
 
 
 !begin_node Beschreibung der VDI-Schreibmodi
-!html_name Description_of_the_VDI_writing_modes
+#!html_name Description_of_the_VDI_writing_modes
 
 !label Replace-Modus
 (!B)Replace:(!b) In diesem Modus Åberschreibt das VDI den Hintergrund mit

--- a/gem/vdi/attribut/text/v_topbot.ui
+++ b/gem/vdi/attribut/text/v_topbot.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node v_topbot
-!html_name v_topbot
+#!html_name v_topbot
 
 (!begin_liste) [Availability]
 
@@ -67,7 +67,7 @@ Text attributes
 
 
 !begin_node Bindings for v_topbot
-!html_name Bindings_for_v_topbot
+#!html_name Bindings_for_v_topbot
 
 !ignore_index
 
@@ -126,7 +126,7 @@ ptsout+6  !! ptsout[3] !! cell_height
 !else
 
 !begin_node v_topbot
-!html_name v_topbot
+#!html_name v_topbot
 
 (!begin_liste) [Beschreibung]
 
@@ -193,7 +193,7 @@ Text-Attribute
 
 
 !begin_node Bindings fÅr v_topbot
-!html_name Bindings_for_v_topbot
+#!html_name Bindings_for_v_topbot
 
 !ignore_index
 

--- a/gem/vdi/attribut/text/vst_kern.ui
+++ b/gem/vdi/attribut/text/vst_kern.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node vst_kern
-!html_name vst_kern
+#!html_name vst_kern
 
 (!begin_liste) [Availability]
 
@@ -80,7 +80,7 @@ vst_track_offset
 
 
 !begin_node Bindings for vst_kern
-!html_name Bindings_for_vst_kern
+#!html_name Bindings_for_vst_kern
 
 !ignore_index
 
@@ -132,7 +132,7 @@ intout+2  !! intout[1] !! pairs
 !else
 
 !begin_node vst_kern
-!html_name vst_kern
+#!html_name vst_kern
 
 (!begin_liste) [Beschreibung]
 
@@ -211,7 +211,7 @@ vst_track_offset
 
 
 !begin_node Bindings fÅr vst_kern
-!html_name Bindings_for_vst_kern
+#!html_name Bindings_for_vst_kern
 
 !ignore_index
 

--- a/gem/vdi/attribut/text/vst_map_mode.ui
+++ b/gem/vdi/attribut/text/vst_map_mode.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node vst_map_mode
-!html_name vst_map_mode
+#!html_name vst_map_mode
 
 (!begin_liste) [Availability]
 
@@ -45,8 +45,8 @@ number of really existing characters.
                
 If you select Unicode and if you want to determine whether a certain character
 exists, you should call vqt_width. If the index returned by
-(!nolink [vqt_width]) is -1, the character does not exist. Instead of
-(!nolink [vqt_width]) you can also call vqt_char_index and map the Unicode index
+vqt_width is -1, the character does not exist. Instead of
+vqt_width you can also call vqt_char_index and map the Unicode index
 into a direct index.
                
 !item [(!nolink [Return]) value:]
@@ -68,7 +68,7 @@ Text attributes
 
 
 !begin_node Bindings for vst_map_mode
-!html_name Bindings_for_vst_map_mode
+#!html_name Bindings_for_vst_map_mode
 
 !ignore_index
 
@@ -116,7 +116,7 @@ intout    !! intout[0] !! Return value
 !else
 
 !begin_node vst_map_mode
-!html_name vst_map_mode
+#!html_name vst_map_mode
 
 (!begin_liste) [Beschreibung]
 
@@ -157,8 +157,8 @@ verfÅgbare Zahl an Zeichen.
 
 Wenn man Unicode anwÑhlt und feststellen mîchte, ob ein bestimmtes Zeichen
 im eingestellten Font existiert, kann man vqt_width fÅr dieses Zeichen
-aufrufen. Sollte (!nolink [vqt_width]) als Index -1 zurÅckliefern, existiert das Zeichen
-nicht. Alternativ zu (!nolink [vqt_width]) kann man auch vqt_char_index aufrufen und den
+aufrufen. Sollte vqt_width als Index -1 zurÅckliefern, existiert das Zeichen
+nicht. Alternativ zu vqt_width kann man auch vqt_char_index aufrufen und den
 fraglichen Unicode in einen direkten Index wandeln lassen.
 
 !item [Ergebnis:]
@@ -180,7 +180,7 @@ Text-Attribute
 
 
 !begin_node Bindings fÅr vst_map_mode
-!html_name Bindings_for_vst_map_mode
+#!html_name Bindings_for_vst_map_mode
 
 !ignore_index
 

--- a/gem/vdi/control/v_loadcache.ui
+++ b/gem/vdi/control/v_loadcache.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node v_loadcache
-!html_name v_loadcache
+#!html_name v_loadcache
 
 (!begin_liste) [Availability]
 
@@ -55,7 +55,7 @@ vqt_cachesize
 !end_node
 
 !begin_node Bindings for v_loadcache
-!html_name Bindings_for_v_loadcache
+#!html_name Bindings_for_v_loadcache
 
 !ignore_index
 
@@ -104,7 +104,7 @@ intout    !! intout[0]     !! Return value
 !else
 
 !begin_node v_loadcache
-!html_name v_loadcache
+#!html_name v_loadcache
 
 (!begin_liste) [Beschreibung]
 
@@ -158,7 +158,7 @@ vqt_cachesize
 !end_node
 
 !begin_node Bindings fÅr v_loadcache
-!html_name Bindings_for_v_loadcache
+#!html_name Bindings_for_v_loadcache
 
 !ignore_index
 

--- a/gem/vdi/control/v_open_bm.ui
+++ b/gem/vdi/control/v_open_bm.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node v_open_bm
-!html_name v_open_bm
+#!html_name v_open_bm
 
 (!begin_liste) [Availability]
 
@@ -143,7 +143,7 @@ Control functions
 
 
 !begin_node Bindings for v_open_bm
-!html_name Bindings_for_v_open_bm
+#!html_name Bindings_for_v_open_bm
 
 !ignore_index
 
@@ -202,7 +202,7 @@ intout    !! intout[0]     !! 1
 !else
 
 !begin_node v_open_bm
-!html_name v_open_bm
+#!html_name v_open_bm
 
 (!begin_liste) [Beschreibung]
 
@@ -356,7 +356,7 @@ Kontrollfunktionen
 
 
 !begin_node Bindings fÅr v_open_bm
-!html_name Bindings_for_v_open_bm
+#!html_name Bindings_for_v_open_bm
 
 !ignore_index
 

--- a/gem/vdi/escape/graphic/v_copies.ui
+++ b/gem/vdi/escape/graphic/v_copies.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node v_copies
-!html_name v_copies
+#!html_name v_copies
 
 !label Printed page, Number of copies
 !label Copies of a printed page
@@ -54,7 +54,7 @@ Special graphic functions
 
 
 !begin_node Bindings for v_copies
-!html_name Bindings_for_v_copies
+#!html_name Bindings_for_v_copies
 
 !ignore_index
 
@@ -104,7 +104,7 @@ intout    !! intout[0] !! Return Value
 !else
 
 !begin_node v_copies
-!html_name v_copies
+#!html_name v_copies
 
 !label Druckseite, Anzahl der Kopien
 !label Kopien einer Druckseite
@@ -158,7 +158,7 @@ Grafikspezial-Funktionen
 
 
 !begin_node Bindings fÅr v_copies
-!html_name Bindings_for_v_copies
+#!html_name Bindings_for_v_copies
 
 !ignore_index
 

--- a/gem/vdi/escape/special/vs_mute.ui
+++ b/gem/vdi/escape/special/vs_mute.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node vs_mute
-!html_name vs_mute
+#!html_name vs_mute
 
 (!begin_liste) [Availability]
 
@@ -56,7 +56,7 @@ v_sound
 
 
 !begin_node Bindings for vs_mute
-!html_name Bindings_for_vs_mute
+#!html_name Bindings_for_vs_mute
 
 !ignore_index
 
@@ -104,7 +104,7 @@ intout    !! intout[0] !! Return Value
 !else
 
 !begin_node vs_mute
-!html_name vs_mute
+#!html_name vs_mute
 
 (!begin_liste) [Beschreibung]
 
@@ -160,7 +160,7 @@ Spezialfunktionen
 
 
 !begin_node Bindings fÅr vs_mute
-!html_name Bindings_for_vs_mute
+#!html_name Bindings_for_vs_mute
 
 !ignore_index
 

--- a/gem/vdi/input/v_show_c.ui
+++ b/gem/vdi/input/v_show_c.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node v_show_c
-!html_name v_show_c
+#!html_name v_show_c
 
 (!begin_liste) [Availability]
 
@@ -41,7 +41,7 @@ graf_mouse is used to switch the mouse cursor on and off.
 
 (!B)Note:(!b) The input functions of the (!nolink [VDI]) work only on the
 (!I)physical(!i) workstation, which is normally used by the (!nolink [AES]).
-Therefore it is better to fall back to using (!nolink [graf_mouse]) instead.
+Therefore it is better to fall back to using graf_mouse instead.
 
 !item [(!nolink [Return]) value:]
 The function does not return a result.
@@ -61,7 +61,7 @@ Input functions
 
 
 !begin_node Bindings for v_show_c
-!html_name Bindings_for_v_show_c
+#!html_name Bindings_for_v_show_c
 
 !ignore_index
 
@@ -104,7 +104,7 @@ intin     !! intin[0]  !! reset
 !else
 
 !begin_node v_show_c
-!html_name v_show_c
+#!html_name v_show_c
 
 (!begin_liste) [Beschreibung]
 
@@ -143,7 +143,7 @@ AES-Funktion graf_mouse verwendet werden.
 
 (!B)Hinweis:(!b) Die Eingabefunktionen des (!nolink [VDI]) arbeiten nur auf der
 (!I)physikalischen(!i) Workstation, die im Normalfall von den (!nolink [AES]) benutzt
-wird. Deshalb sollte man besser auf (!nolink [graf_mouse]) zurÅckgreifen.
+wird. Deshalb sollte man besser auf graf_mouse zurÅckgreifen.
 
 !item [Ergebnis:]
 Die Funktion liefert kein Ergebnis.
@@ -163,7 +163,7 @@ Eingabefunktionen
 
 
 !begin_node Bindings fÅr v_show_c
-!html_name Bindings_for_v_show_c
+#!html_name Bindings_for_v_show_c
 
 !ignore_index
 

--- a/gem/vdi/inquire/v_delete_driver_info.ui
+++ b/gem/vdi/inquire/v_delete_driver_info.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node v_delete_driver_info
-!html_name v_delete_driver_info
+#!html_name v_delete_driver_info
 
 (!begin_liste) [Availability]
 
@@ -49,7 +49,7 @@ Inquire functions
 
 
 !begin_node Bindings for v_delete_driver_info
-!html_name Bindings_for_v_delete_driver_info
+#!html_name Bindings_for_v_delete_driver_info
 
 !ignore_index
 
@@ -96,7 +96,7 @@ intin     !! intin[0..1]    !! drv_info
 !else
 
 !begin_node v_delete_driver_info
-!html_name v_delete_driver_info
+#!html_name v_delete_driver_info
 
 (!begin_liste) [Beschreibung]
 
@@ -141,7 +141,7 @@ Auskunftsfunktionen
 
 
 !begin_node Bindings fÅr v_delete_driver_info
-!html_name Bindings_for_v_delete_driver_info
+#!html_name Bindings_for_v_delete_driver_info
 
 !ignore_index
 

--- a/gem/vdi/inquire/vq_devinfo.ui
+++ b/gem/vdi/inquire/vq_devinfo.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node vq_devinfo
-!html_name vq_devinfo
+#!html_name vq_devinfo
 
 (!begin_liste) [Availability]
 
@@ -67,7 +67,7 @@ Inquire functions
 
 
 !begin_node Bindings for vq_devinfo
-!html_name Bindings_for_vq_devinfo
+#!html_name Bindings_for_vq_devinfo
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]
@@ -119,7 +119,7 @@ ptsout+2  !! ptsout[1..p-1] !! device_name[0..p-2]
 !else
 
 !begin_node vq_devinfo
-!html_name vq_devinfo
+#!html_name vq_devinfo
 
 (!begin_liste) [Beschreibung]
 
@@ -182,7 +182,7 @@ Auskunftsfunktionen
 
 
 !begin_node Bindings fÅr vq_devinfo
-!html_name Bindings_for_vq_devinfo
+#!html_name Bindings_for_vq_devinfo
 !ignore_index
 
 (!begin_liste) [Umsetzung]

--- a/gem/vdi/inquire/vq_ptsinsz.ui
+++ b/gem/vdi/inquire/vq_ptsinsz.ui
@@ -14,7 +14,7 @@
 !iflang [english]
 
 !begin_node vq_ptsinsz
-!html_name vq_ptsinsz
+#!html_name vq_ptsinsz
 
 (!begin_liste) [Availability]
 
@@ -59,7 +59,7 @@ Inquire functions
 !else
 
 !begin_node vq_ptsinsz
-!html_name vq_ptsinsz
+#!html_name vq_ptsinsz
 
 (!begin_liste) [Beschreibung]
 

--- a/gem/vdi/inquire/vq_scrninfo.ui
+++ b/gem/vdi/inquire/vq_scrninfo.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node vq_scrninfo
-!html_name vq_scrninfo
+#!html_name vq_scrninfo
 
 (!begin_liste) [Availability]
 
@@ -170,7 +170,7 @@ NVDI ~ (!link [Bitmap format for printer drivers][Bitmap format for printer driv
 
 
 !begin_node Bindings for vq_scrninfo
-!html_name Bindings_for_vq_scrninfo
+#!html_name Bindings_for_vq_scrninfo
 !ignore_index
 
 (!begin_liste) [GEM-Arrays]
@@ -217,7 +217,7 @@ intout    !! intout[0..272] !! work_out[0..272]
 
 
 !begin_node Examples for vq_scrninfo
-!html_name Examples_for_vq_scrninfo
+#!html_name Examples_for_vq_scrninfo
 
 (!B)256 colors on the Falcon:(!b)
 
@@ -372,7 +372,7 @@ See also: vq_scrninfo ~ Raster formats ~ NVDI
 !else
 
 !begin_node vq_scrninfo
-!html_name vq_scrninfo
+#!html_name vq_scrninfo
 
 (!begin_liste) [Beschreibung]
 
@@ -433,11 +433,11 @@ Anzahl der Ebenen (Bits) pro Pixel
 !item [work_out[4!]:]
 Farbanzahl oder 0L (mehr als 2*10^31 Farben)
 !item [work_out[5!]:]
-Breite einer Zeile in Bytes (ab (!nolink [EdDI]) 1.1)
+Breite einer Zeile in Bytes (ab EdDI 1.1)
 !item [work_out[6!]:]
 +
 !item [work_out[7!]:]
-Adresse der Bitmap (erst ab (!nolink [EdDI]) Version 1.1 verfÅgbar).
+Adresse der Bitmap (erst ab EdDI Version 1.1 verfÅgbar).
 !item [work_out[8!]:]
 Anzahl der Bits fÅr die Rot-IntensitÑt
 !item [work_out[9!]:]
@@ -535,7 +535,7 @@ NVDI ~
 
 
 !begin_node Bindings fÅr vq_scrninfo
-!html_name Bindings_for_vq_scrninfo
+#!html_name Bindings_for_vq_scrninfo
 !ignore_index
 
 (!begin_liste) [Umsetzung]
@@ -580,7 +580,7 @@ intout    !! intout[0..272] !! work_out[0..272]
 !end_node
 
 !begin_node Beispiele zu vq_scrninfo
-!html_name Examples_for_vq_scrninfo
+#!html_name Examples_for_vq_scrninfo
 
 Die folgende Liste enthÑlt Beispiele fÅr das von vq_scrninfo belegte
 work_out-Array fÅr verschiedene Bildschirmauflîsungen:

--- a/gem/vdi/inquire/vqin_mode.ui
+++ b/gem/vdi/inquire/vqin_mode.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node vqin_mode
-!html_name vqin_mode
+#!html_name vqin_mode
 
 (!begin_liste) [Availability]
 
@@ -67,7 +67,7 @@ vrq_string ~ vsm_string
 
 
 !begin_node Bindings for vqin_mode
-!html_name Bindings_for_vqin_mode
+#!html_name Bindings_for_vqin_mode
 
 !ignore_index
 
@@ -114,7 +114,7 @@ intout    !! intout[0] !! input_mode
 !else
 
 !begin_node vqin_mode
-!html_name vqin_mode
+#!html_name vqin_mode
 
 (!begin_liste) [Beschreibung]
 
@@ -179,7 +179,7 @@ vrq_string ~ vsm_string
 
 
 !begin_node Bindings fÅr vqin_mode
-!html_name Bindings_for_vqin_mode
+#!html_name Bindings_for_vqin_mode
 
 !ignore_index
 

--- a/gem/vdi/metafile.u
+++ b/gem/vdi/metafile.u
@@ -5,7 +5,7 @@
 !iflang [english]
 
 !begin_node Metafile format
-!html_name Metafile_format
+#!html_name Metafile_format
 
 Metafiles are nothing more than saved (!nolink [VDI]) commands, which are used in
 object-oriented programs such as (!I)GEMDRAW(!i) or (!I)Kandinsky.(!i) The main
@@ -112,7 +112,7 @@ Metafile drivers ~ Metafile functions ~ (!link [Sub-opcodes][Metafile sub-opcode
 
 
 !begin_node Metafile sub-opcodes
-!html_name Metafile_sub-opcodes
+#!html_name Metafile_sub-opcodes
 
 The GEM metafile format can be extended by user-defined sub-opcodes
 to almost any extent without giving rise to incompatibilities. One
@@ -1052,7 +1052,7 @@ Metafile-Treiber ~  Metafile-Funktionen  ~ (!link [Sub-Opcodes][Metafile Sub-Opc
 
 
 !begin_node Metafile Sub-Opcodes
-!html_name Metafile_sub-opcodes
+#!html_name Metafile_sub-opcodes
 
 Das GEM-Metafile-Format kann durch benutzerdefinierte Sub-Opcodes nahezu
 beliebig erweitert werden, ohne daž Inkompatibilit„ten entstehen. Es sollten

--- a/gem/vdi/raster/vr_transfer_bits.ui
+++ b/gem/vdi/raster/vr_transfer_bits.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node vr_transfer_bits
-!html_name vr_transfer_bits
+#!html_name vr_transfer_bits
 
 (!begin_liste) [Availability]
 
@@ -48,7 +48,7 @@ Transfer function mode
 The function vr_transfer_bit combines the source bitmap(!I)src_bm(!i) with
 the destination bitmap (!I)dst_bm(!i), where (!I)mode(!i) specifies the
 transfer function. The source rectangle is passed in (!I)src_rect(!i) and the
-destination rectangle in (!I)dst_rect.(!i) The coordinates here are specified
+destination rectangle in (!I)dst_rect(!i). The coordinates here are specified
 (as for all other (!nolink [VDI]) functions) as discrete values.
 
 If the source and destination rectangles do not have the same size,
@@ -393,7 +393,7 @@ Raster functions
 
 
 !begin_node Bindings for vr_transfer_bits
-!html_name Bindings_for_vr_transfer_bits
+#!html_name Bindings_for_vr_transfer_bits
 
 !ignore_index
 
@@ -456,7 +456,7 @@ ptsin+8   !! ptsin[4..7] !! dst_rect
 !else
 
 !begin_node vr_transfer_bits
-!html_name vr_transfer_bits
+#!html_name vr_transfer_bits
 
 (!begin_liste) [Beschreibung]
 
@@ -870,7 +870,7 @@ Rasterfunktionen
 
 
 !begin_node Bindings fÅr vr_transfer_bits
-!html_name Bindings_for_vr_transfer_bits
+#!html_name Bindings_for_vr_transfer_bits
 
 !ignore_index
 

--- a/gem/vdi/structures/font_hdr.ui
+++ b/gem/vdi/structures/font_hdr.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node FONT_HDR
-!html_name FONT_HDR
+#!html_name FONT_HDR
 
 !label Bitmap fonts, Header for
 
@@ -89,7 +89,7 @@ vst_unload_fonts ~ vqt_fontheader
 !else
 
 !begin_node FONT_HDR
-!html_name FONT_HDR
+#!html_name FONT_HDR
 
 !label Bitmap-Fonts, Header bei
 

--- a/gemdos/file/fattrib.ui
+++ b/gemdos/file/fattrib.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node Fattrib
-!html_name Fattrib
+#!html_name Fattrib
 
 (!begin_liste) [Availability]
 !item [Name:]
@@ -80,7 +80,7 @@ File functions
 
 
 !begin_node Bindings for Fattrib
-!html_name Bindings_for_Fattrib
+#!html_name Bindings_for_Fattrib
 
 !ignore_index
 (!begin_liste) [Assembler:]
@@ -108,7 +108,7 @@ Fehler%=Gemdos(&H43,L:filename%,W:wflag%,W:attrib%)
 
 
 !begin_node Fattrib
-!html_name Fattrib
+#!html_name Fattrib
 
 (!begin_liste) [Beschreibung]
 !item [Name:]
@@ -187,7 +187,7 @@ Dateifunktionen
 
 
 !begin_node Bindings fÅr Fattrib
-!html_name Bindings_for_Fattrib
+#!html_name Bindings_for_Fattrib
 
 !ignore_index
 (!begin_liste) [Assembler:]

--- a/gemdos/file/fchmod.ui
+++ b/gemdos/file/fchmod.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node Fchmod
-!html_name Fchmod
+#!html_name Fchmod
 
 (!begin_liste) [Availability]
 !item [Name:]
@@ -91,7 +91,7 @@ File functions
 
 
 !begin_node Bindings for Fchmod
-!html_name Bindings_for_Fchmod
+#!html_name Bindings_for_Fchmod
 
 !ignore_index
 (!begin_liste) [Assembler:]
@@ -115,7 +115,7 @@ addq.l    #8,sp        ; correct stack
 
 
 !begin_node Fchmod
-!html_name Fchmod
+#!html_name Fchmod
 
 (!begin_liste) [Beschreibung]
 !item [Name:]
@@ -206,7 +206,7 @@ Dateifunktionen
 
 
 !begin_node Bindings fÅr Fchmod
-!html_name Bindings_for_Fchmod
+#!html_name Bindings_for_Fchmod
 
 !ignore_index
 (!begin_liste) [Assembler:]

--- a/gemdos/file/fforce.ui
+++ b/gemdos/file/fforce.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node Fforce
-!html_name Fforce
+#!html_name Fforce
 
 (!begin_liste) [Availability]
 !item [Name:]
@@ -89,7 +89,7 @@ exits and should not be closed by the parent.
 
 
 !begin_node Bindings for Fforce
-!html_name Bindings_for_Fforce
+#!html_name Bindings_for_Fforce
 
 !ignore_index
 (!begin_liste) [Assembler:]
@@ -116,7 +116,7 @@ Fehler%=Gemdos(&H46,W:stdh%,W:nonstdh%)
 
 
 !begin_node Fforce
-!html_name Fforce
+#!html_name Fforce
 
 (!begin_liste) [Beschreibung]
 !item [Name:]
@@ -208,7 +208,7 @@ Child Prozess beendet und nicht vom Parent geschlossen werden darf.
 
 
 !begin_node Bindings fÅr Fforce
-!html_name Bindings_for_Fforce
+#!html_name Bindings_for_Fforce
 
 !ignore_index
 (!begin_liste) [Assembler:]

--- a/gemdos/gemdos.u
+++ b/gemdos/gemdos.u
@@ -1916,7 +1916,7 @@ groûe AbstÑnde kann dieser Vorgang natÅrlich auch wiederholt werden. Eine
 gekennzeichnet.
 
 Querverweis:
-Fcntl ~ (!link [ARHEADER][Archivheader (ARHEADER)]) ~ OHEADER ~
+Fcntl ~ (!link [ARHEADER][Archivheader (ARHEADER!)]) ~ OHEADER ~
 OSHEADER ~ PSETFLAGS ~ (!link [Die Programmflags][Die Programmflags])
 
 !begin_node Die Programmflags

--- a/gemdos/network/Nversion.ui
+++ b/gemdos/network/Nversion.ui
@@ -4,7 +4,7 @@
 
 
 !begin_node Nversion
-!html_name Nversion
+#!html_name Nversion
 
 (!begin_liste) [Availability]
 !item [Name:]
@@ -43,7 +43,7 @@ Network functions
 
 
 !begin_node Bindings for Nversion
-!html_name Bindings_for_Nversion
+#!html_name Bindings_for_Nversion
 
 !ignore_index
 (!begin_liste) [Assembler:]
@@ -65,7 +65,7 @@ addq.l    #2,sp        ; correct stack
 
 
 !begin_node Nversion
-!html_name Nversion
+#!html_name Nversion
 
 (!begin_liste) [Beschreibung]
 !item [Name:]
@@ -104,7 +104,7 @@ Netzwerkfunktionen
 
 
 !begin_node Bindings fÅr Nversion
-!html_name Bindings_for_Nversion
+#!html_name Bindings_for_Nversion
 
 !ignore_index
 (!begin_liste) [Assembler:]

--- a/gemdos/structures/ltchars.ui
+++ b/gemdos/structures/ltchars.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node ltchars
-!html_name ltchars
+#!html_name ltchars
 
 !begin_verbatim
 struct ltchars
@@ -23,7 +23,7 @@ See also: struct tty ~
 !else
 
 !begin_node ltchars
-!html_name ltchars
+#!html_name ltchars
 
 !begin_verbatim
 struct ltchars

--- a/gemdos/structures/sgttyb.ui
+++ b/gemdos/structures/sgttyb.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node sgttyb
-!html_name sgttyb
+#!html_name sgttyb
 
 !begin_verbatim
 struct sgttyb
@@ -22,7 +22,7 @@ See also: struct tty ~
 !else
 
 !begin_node sgttyb
-!html_name sgttyb
+#!html_name sgttyb
 
 !begin_verbatim
 struct sgttyb

--- a/gemdos/structures/tchars.ui
+++ b/gemdos/structures/tchars.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node tchars
-!html_name tchars
+#!html_name tchars
 
 !begin_verbatim
 struct tchars
@@ -23,7 +23,7 @@ See also: struct tty ~
 !else
 
 !begin_node tchars
-!html_name tchars
+#!html_name tchars
 
 !begin_verbatim
 struct tchars

--- a/gemdos/system/super.ui
+++ b/gemdos/system/super.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node Super
-!html_name Super
+#!html_name Super
 (!begin_liste) [Availability]
 !item [Name:]
 ØsupervisorÆ - Switch supervisor-mode.
@@ -52,7 +52,7 @@ System functions
 
 
 !begin_node Bindings for Super
-!html_name Bindings_for_Super
+#!html_name Bindings_for_Super
 !ignore_index
 (!begin_liste) [Assembler:]
 !item [C:]
@@ -70,7 +70,7 @@ addq.l    #6,sp        ; Correct stack
 
 
 !begin_node Note for the use of the GEMDOS function Super
-!html_name Note_for_the_use_of_the_GEMDOS_function_Super
+#!html_name Note_for_the_use_of_the_GEMDOS_function_Super
 
 The function (!nolink [Super]) in switching to the supervisor-mode sets the
 (!nolink [Super]) stack pointer to the user-stack of the program. This can
@@ -95,7 +95,7 @@ restriction to the supervisor stack size.
 
 
 !begin_node Super
-!html_name Super
+#!html_name Super
 (!begin_liste) [Beschreibung]
 !item [Name:]
 ØsupervisorÆ - Supervisor-Modus umschalten.
@@ -146,7 +146,7 @@ Systemfunktionen
 
 
 !begin_node Bindings fÅr Super
-!html_name Bindings_for_Super
+#!html_name Bindings_for_Super
 !ignore_index
 (!begin_liste) [Assembler:]
 !item [C:]
@@ -164,7 +164,7 @@ addq.l    #6,sp        ; Stack korrigieren
 
 
 !begin_node Hinweis zur Verwendung der GEMDOS-Funktion Super
-!html_name Note_for_the_use_of_the_GEMDOS_function_Super
+#!html_name Note_for_the_use_of_the_GEMDOS_function_Super
 
 Die Funktion (!nolink [Super]) setzt bei der Umschaltung in den
 Supervisor-Modus den (!nolink [Super])-Stackpointer auf den User-Stack des

--- a/gemdos/system/sysconf.ui
+++ b/gemdos/system/sysconf.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node Sysconf
-!html_name Sysconf
+#!html_name Sysconf
 
 (!begin_liste) [Availability]
 !item [Name:]
@@ -54,7 +54,7 @@ System functions
 
 
 !begin_node Bindings for Sysconf
-!html_name Bindings_for_Sysconf
+#!html_name Bindings_for_Sysconf
 
 !ignore_index
 (!begin_liste) [Assembler:]
@@ -75,7 +75,7 @@ addq.l    #4,sp        ; Correct stack
 !else
 
 !begin_node Sysconf
-!html_name Sysconf
+#!html_name Sysconf
 
 (!begin_liste) [Beschreibung]
 !item [Name:]
@@ -129,7 +129,7 @@ Systemfunktionen
 
 
 !begin_node Bindings fÅr Sysconf
-!html_name Bindings_for_Sysconf
+#!html_name Bindings_for_Sysconf
 
 !ignore_index
 (!begin_liste) [Assembler:]

--- a/magic/DFS/dfs_de.ui
+++ b/magic/DFS/dfs_de.ui
@@ -1,10 +1,10 @@
 !begin_node Das DFS-Konzept von MagiC
 !label MagiC, DFS-Konzept in
 
-(!nolink [MagiC]) erm”glicht wie MultiTOS die Einbindung alternativer Dateisysteme (sog.
+MagiC erm”glicht wie MultiTOS die Einbindung alternativer Dateisysteme (sog.
 XFSs). Fest in MagiC integriert ist nur ein einziges XFS, das DOS_XFS. Auf
 diesem XFS setzen wiederum Untertreiber, sogenannte DFS (dos file system)
-auf, von denen zwei in (!nolink [MagiC]) integriert sind, und zwar das FAT-Dateisystem
+auf, von denen zwei in MagiC integriert sind, und zwar das FAT-Dateisystem
 und das U-Dateisystem (das fr Laufwerk U:).
 
 Ein DOS-Dateisystem (DFS) wird vom DOS_XFS aufgerufen. Hier stehen nur die
@@ -65,14 +65,14 @@ Querverweis: (!link [Aufbau eines XFS][Der Aufbau eines XFS])  ~ MagiC
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *
 a1 !! = !! long df[4]
 -> d0 !! = !! long errcode
 !end_table
 
 !item [Beschreibung:]
-Fr Dfree(). I.a. reicht es, aus dem (!link [DD][Der Verzeichnis-Deskriptor (DD)])
-den zugeh”rigen (!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) zu ermitteln und
+Fr Dfree(). I.a. reicht es, aus dem (!link [DD][Der Verzeichnis-Deskriptor (DD!)])
+den zugeh”rigen (!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) zu ermitteln und
 den freien Platz auf dem ganzen Laufwerk anzugeben.
 
 !item [Gruppe:]
@@ -94,8 +94,8 @@ den freien Platz auf dem ganzen Laufwerk anzugeben.
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *dd
-a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR)]) *dir
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *dd
+a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR!)]) *dir
 -> d0 !! = !! long errcode
 ggf. !! ~ !! ~
 a0 !! = !! LINK *l
@@ -139,8 +139,8 @@ Ggfs. werden noch andere Daten des FD ver„ndert.
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *dd
-a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR)]) *dir
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *dd
+a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR!)]) *dir
 -> d0 !! = !! long index oder errcode
 !end_table
 
@@ -170,7 +170,7 @@ dem die Datei liegt.
 !item [Parameter:]
 !begin_table [r l l]
 d0 !! = !! int mode
-a0 !! = !! (!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) *d
+a0 !! = !! (!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) *d
 -> d0 !! = !! long errcode
 !end_table
 
@@ -228,12 +228,12 @@ Auswurf verweigert.
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) *d
+a0 !! = !! (!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) *d
 -> d0 !! = !! long errcode
 !end_table
 
 !item [Beschreibung:]
-(!nolink [MagiC]) untersttzt genau 26 gleichzeitig aktive Dateisysteme denen die
+MagiC untersttzt genau 26 gleichzeitig aktive Dateisysteme denen die
 Buchstaben 'A'..'Z' zugeordnet sind. Dieser Eintrag hat zwei Aufgaben:
 
 !begin_enumerate
@@ -274,7 +274,7 @@ Buchstaben 'A'..'Z' zugeordnet sind. Dieser Eintrag hat zwei Aufgaben:
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *fd
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *fd
 -> d0 !! = !! long errcode
 !end_table
 
@@ -306,8 +306,8 @@ Datei muž erweitert und der neue Platz mit Nullen initialisiert werden.
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *dd
-a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR)]) *dir
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *dd
+a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR!)]) *dir
 d0 !! = !! int cmd
 d1 !! = !! long arg
 -> d0 !! = !! long errcode
@@ -347,8 +347,8 @@ werden.
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *dd
-a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR)]) *dir
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *dd
+a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR!)]) *dir
 d0 !! = !! long dirpos
 -> d0 !! = !! long errcode
 !end_table
@@ -378,8 +378,8 @@ Verzeichniseintrags und Zugriffsprfungen werden vom DOS_XFS durchgefhrt.
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *dd
-a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR)]) *dir oder NULL
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *dd
+a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR!)]) *dir oder NULL
 d0 !! = !! int mode
 d1 !! = !! XATTR *xattr
 -> d0 !! = !! long errcode
@@ -503,7 +503,7 @@ es z.B. m”glich, den integrierten DOS-Treiber zu berladen.
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *dd
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *dd
 d0 !! = !! int which
 -> d0 !! = !! long val oder Fehlercode
 !end_table
@@ -539,8 +539,8 @@ DP_MODEATTR !! (7) !! zul„ssige Dateitypen (ab 21.05.95)
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *dd
-a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR)]) *dir
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *dd
+a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR!)]) *dir
 -> d0 !! = !! long errcode
 ggf. !! ~ !! ~
 a0 !! = !! LINK *l
@@ -571,8 +571,8 @@ zurckgegeben werden, und d0 muž den Wert ELINK haben.
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) * d
-a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR)]) *dir
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) * d
+a1 !! = !! (!link [DIR][Der Verzeichniseintrag (DIR!)]) *dir
 d0 !! = !! long pos
 d1 !! = !! DTA *dta
 -> d0 !! = !! long errcode
@@ -624,7 +624,7 @@ stattfinden kann.
 !item [Parameter:]
 !begin_table [r l l]
 a0 !! = !! DTA *dta
-a1 !! = !! (!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) *dmd
+a1 !! = !! (!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) *dmd
 -> d0 !! = !! long errcode
 ggf. !! ~ !! ~
 a0 !! = !! LINK *l
@@ -648,7 +648,7 @@ vergleicht Dateinamen
 !item [conv_path_elem]
 wandelt Dateinamen um
 !item [init_DTA]
-kopiert Daten vom (!link [DIR][Der Verzeichniseintrag (DIR)]) in die (!nolink [DTA])
+kopiert Daten vom (!link [DIR][Der Verzeichniseintrag (DIR!)]) in die (!nolink [DTA])
 !end_xlist
 
 !item [Gruppe:]
@@ -671,7 +671,7 @@ kopiert Daten vom (!link [DIR][Der Verzeichniseintrag (DIR)]) in die (!nolink [D
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) *d
+a0 !! = !! (!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) *d
 -> d0 !! = !! long errcode
 !end_table
 
@@ -702,11 +702,11 @@ Zurckgeliefert wird ein Fehlercode. Wenn das DFS keine Pufferverwaltung hat
 Bei der Arbeit mit einem DFS sind die folgenden Datenstrukturen wichtig:
 
 !begin_itemize !compressed
-!item (!link [DIR][Der Verzeichniseintrag (DIR)])      (Verzeichniseintrag)
-!item (!link [DMD][Der Drive-Medium-Deskriptor (DMD)])      (Medium-Deskriptor)
+!item (!link [DIR][Der Verzeichniseintrag (DIR!)])      (Verzeichniseintrag)
+!item (!link [DMD][Der Drive-Medium-Deskriptor (DMD!)])      (Medium-Deskriptor)
 !item DTA      (Disk-Transfer-Area)
-!item (!link [DIR][Der Verzeichniseintrag (DIR)])       ((!nolink [Datei-Deskriptor]))
-!item (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])  (DOS-Ger„tetreiber)
+!item (!link [DIR][Der Verzeichniseintrag (DIR!)])       ((!nolink [Datei-Deskriptor]))
+!item (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])  (DOS-Ger„tetreiber)
 !end_itemize
 
 Querverweis: XFS-Strukturen
@@ -779,7 +779,7 @@ Querverweis: (!link [DFS-Konzept in MagiC][Das DFS-Konzept von MagiC]) ~
 
 !item [Parameter:]
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 -> d0 !! = !! long errcode
 !end_table
 
@@ -803,7 +803,7 @@ fd. Gibt ddev_open einen Fehlercode zurck, wird der FD einfach wieder vom
 DOS-XFS freigegeben.
 
 !item [Gruppe:]
-(!link [DOS-Ger„tetreiber][Der Ger„tetreiber (MX_DDEV)])
+(!link [DOS-Ger„tetreiber][Der Ger„tetreiber (MX_DDEV!)])
 
 !item [Querverweis:]
 ---
@@ -820,7 +820,7 @@ Puffer zurckzuschreiben.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file,
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file,
 -> d0 !! = !! long errcode
 !end_table
 !end_node
@@ -832,7 +832,7 @@ Siehe dev_read.
 
 (!B)Parameter-bergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 d0 !! = !! long count
 a1 !! = !! char *buffer
 -> d0 !! = !! long amount
@@ -848,7 +848,7 @@ Verzeichnisses oder das Datum des letzten Zugriffs zu kmmern.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 d0 !! = !! long count
 a1 !! = !! char *buffer
 -> d0 !! = !! long amount
@@ -863,7 +863,7 @@ Siehe dev_stat.
 
 (!B)Parameter-bergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 a1 !! = !! MAGX_UNSEL *unselect oder NULL
 d0 !! = !! int rwflag
 d1 !! = !! long apcode
@@ -879,7 +879,7 @@ Siehe dev_seek.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 d0 !! = !! long where
 d1 !! = !! int mode
 -> d0 !! = !! long position
@@ -896,7 +896,7 @@ Fcntl(FUTIME, ...) auf Fdatime um.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 a1 !! = !! int d[2]
 d0 !! = !! int setflag
 -> d0 !! = !! long errcode
@@ -932,7 +932,7 @@ freizugeben und sich damit aus dem System zurckzuziehen.
 
 (!B)Parameter-bergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *directory
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *directory
 a1 !! = !! DIR *dir
 -> d0 !! = !! long errcode
 !end_table
@@ -947,7 +947,7 @@ dann fhrt das DOS_XFS die Standardprozedur durch, d.h. ruft ddev_read auf.
 
 (!B)Parameter-bergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 d0 !! = !! int mode
 -> d0 !! = !! unsigned long c
 !end_table
@@ -963,7 +963,7 @@ ddev_read auf.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 a1 !! = !! char *buf
 d1 !! = !! long size
 d0 !! = !! int mode
@@ -980,7 +980,7 @@ dann fhrt das DOS_XFS die Standardprozedur durch, d.h. ruft ddev_write auf.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 d0 !! = !! int mode
 d1 !! = !! long value
 -> d0 !! = !! unsigned long count

--- a/magic/XFS/xfs_de.ui
+++ b/magic/XFS/xfs_de.ui
@@ -3,9 +3,9 @@
 
 MagiC erm”glicht wie MultiTOS die Einbindung alternativer Dateisysteme, und
 damit prinzipiell die Verwendung langer Dateinamen. Aus verschiedenen
-Grnden wurde in (!nolink [MagiC]) jedoch ein anderer Ansatz gew„hlt, als in Atari's
+Grnden wurde in MagiC jedoch ein anderer Ansatz gew„hlt, als in Atari's
 L”sung. Dies hat leider zur Folge, da die fr MultiTOS vorhandenen XFS's
-(Minix-XFS, CD-ROM-XFS, ...) unter (!nolink [MagiC]) (!I)nicht(!i) eingesetzt werden
+(Minix-XFS, CD-ROM-XFS, ...) unter MagiC (!I)nicht(!i) eingesetzt werden
 k”nnen. Dieses Kapitel beschreibt die folgenden Punkte:
 
 !begin_itemize !compressed
@@ -28,7 +28,7 @@ VFAT-XFS in MagiC ~  (!link [DFS-Konzept in MagiC][Das DFS-Konzept von MagiC])
 Das GEMDOS war bisher der konservativste Teil des Betriebssystems MagiC.
 Fr Netzwerktreiber muten praktisch s„mtliche DOS-Aufrufe einschlielich
 Pexec nachgebildet werden, ohne auf einer tieferen Ebene eingreifen zu
-k”nnen. In (!nolink [MagiC]) 1.x (wie in TOS) war das DOS nicht einmal reentrant, da
+k”nnen. In MagiC 1.x (wie in TOS) war das DOS nicht einmal reentrant, da
 ein statisch angelegter Stack verwendet wurde.
 
 In MultiTOS/MiNT wird das Problem dermaen umgangen, da gewissermaen
@@ -53,7 +53,7 @@ Aufrufe des Dateisystemtreibers fr einen DOS-Aufruf notwendig. Schlielich
 ist der MiNT-Kernel selbst sehr lang, liegt aber zum groen Teil brach,
 solange keine anderen Dateisysteme als DOS eingesetzt werden.
 
-(!B)Unter (!nolink [MagiC]) wurde ein anderer Ansatz gew„hlt(!b), der darin bestand, das
+(!B)Unter MagiC wurde ein anderer Ansatz gew„hlt(!b), der darin bestand, das
 gesamte (!nolink [GEMDOS]) einschlielich der Lowlevel-Funktionen fr die
 Sektorpufferung von Grund auf neu zu schreiben und in insgesamt drei, vier
 oder fnf Schichten zu zerlegen, in die von auen (durch nachgeladene
@@ -84,13 +84,13 @@ aber immer wieder verschiedene.
 (!B)Die Schichten im einzelnen:(!b)
 
 !begin_enumerate !compressed
-!item (!B)Der DOS-Kernel(!b). Er liegt in (!nolink [MagiC]) selbst und wird direkt von
+!item (!B)Der DOS-Kernel(!b). Er liegt in MagiC selbst und wird direkt von
       den Anwenderprogrammen ber Trap #1 aufgerufen. Er enth„lt Module fr
       die Speicherverwaltung, fr die Prozeverwaltung und fr die
       Dateiverwaltung. Letztere hat die folgenden Unterschichten.
 !item (!B)Das Dateisystem(!b) (XFS = eXtended File System). Sein Aufbau ist
       grunds„tzlich verschieden von einem MiNT-XFS, erfllt aber denselben
-      Zweck. (!nolink [MagiC]) fr Ataris enth„lt nur ein einziges XFS, das sogenannte
+      Zweck. MagiC fr Ataris enth„lt nur ein einziges XFS, das sogenannte
       DOS_XFS, andere k”nnen eingebunden werden. Die Macintosh-Version
       (MagiC Mac) enth„lt (!I)zus„tzlich(!i) ein Mac-XFS. Speziell dieses
       Dateisystem greift wieder auf Untertreiber zu:
@@ -149,8 +149,8 @@ aber immer wieder verschiedene.
       Parameterbergabe und -rckgabe erfordert eine Implementation aller
       Dateisysteme und -treiber in Assembler, zumindest fr die meisten
       Funktionen.
-!item Der Aufbau des MX_DDEV-Dateitreibers hat sich seit (!nolink [MagiC]) V2.10
-      ge„ndert. Der Beispieltreiber DEV_LPT1 darf unter (!nolink [MagiC]) 3.00 nicht
+!item Der Aufbau des MX_DDEV-Dateitreibers hat sich seit MagiC V2.10
+      ge„ndert. Der Beispieltreiber DEV_LPT1 darf unter MagiC 3.00 nicht
       verwendet werden. Die Konzepte sind jedoch identisch geblieben, nur
       ein paar Konstanten haben sich ge„ndert. Ein neuer Beispieltreiber ist
       noch nicht fertig.
@@ -221,7 +221,7 @@ Querverweis:
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name
 !item [d0 =]
@@ -263,7 +263,7 @@ keine symbolischen Links erkannt.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name
 !item [d0 =]
@@ -299,7 +299,7 @@ Wird vom XFS_DOS (!I)nicht(!i) untersttzt.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name
 !item [d0 =]
@@ -338,7 +338,7 @@ Wird vom XFS_DOS (!I)nicht(!i) untersttzt.
 !item [Parameter:]
 !begin_xlist !compressed [a0 =]
 !item [a0 =]
-(!link [DHD][Der Directory-Handle-Deskriptor (DHD)]) *dhd
+(!link [DHD][Der Directory-Handle-Deskriptor (DHD!)]) *dhd
 !item [-> d0 =]
 long errcode
 !end_xlist
@@ -367,7 +367,7 @@ Analog zu MiNT.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name
 !item [d0 =]
@@ -402,7 +402,7 @@ Fr Dcntl. Jedes XFS sollte FUTIME untersttzen.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name (ohne Pfad)
 !item [-> d0 =]
@@ -433,13 +433,13 @@ Fr Dcreate ben”tigt.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [-> d0 =]
 long errcode
 !end_xlist
 
 !item [Beschreibung:]
-Diese Funktion musste ab MagiC Version 4.01 ge„ndert werden. Fr (!nolink [MagiC]) <
+Diese Funktion musste ab MagiC Version 4.01 ge„ndert werden. Fr MagiC <
 4.01 (Kernelversion < 3) gilt:
 
 Beim L”schen ist darauf zu achten, da kein Verzeichnis durch den Kernel
@@ -449,7 +449,7 @@ liegen. ELINK darf nicht zurckgegeben werden, symbolische Links drfen
 nicht behandelt werden. Die Zugriffsberechtigung mu (falls eine existiert)
 vom XFS geprft werden.
 
-Fr (!nolink [MagiC]) < 4.01 (Kernelversion >= 3) gilt:
+Fr MagiC < 4.01 (Kernelversion >= 3) gilt:
 
 Wegen Reentranzproblematiken ergeben sich einigen nderungen, wobei der
 Kernel dem XFS Zugriffskontrollen abnimmt und weiterhin der Kernel den DD
@@ -503,7 +503,7 @@ Nochmal im Zusammenhang:
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 long[4]
 !item [-> d0 =]
@@ -534,7 +534,7 @@ Fr Dfree. XFS_DOS ruft direkt den zust„ndigen DFS-Treiber auf.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name
 !item [d0 =]
@@ -572,11 +572,11 @@ Wenn der Puffer zu klein ist (bufsize kleiner als der Pfad), mu wie in MiNT
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [d0 =]
 int tosflag
 !item [-> d0 =]
-(!link [DHD][Der Directory-Handle-Deskriptor (DHD)]) *dhd  oder Fehlercode
+(!link [DHD][Der Directory-Handle-Deskriptor (DHD!)]) *dhd  oder Fehlercode
 !end_xlist
 
 !item [Beschreibung:]
@@ -608,7 +608,7 @@ krzen und darf keine Dateikennung zurckgeben.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [d0 =]
 int which
 !item [-> d0 =]
@@ -684,7 +684,7 @@ Ab der MagiC Version vom 21.5.95 wird weiterhin untersttzt:
 !item [Parameter:]
 !begin_xlist !compressed [->a0 =]
 !item [a0 =]
-(!link [DHD][Der Directory-Handle-Deskriptor (DHD)]) *dhd
+(!link [DHD][Der Directory-Handle-Deskriptor (DHD!)]) *dhd
 !item [d0 =]
 int  size
 !item [a1 =]
@@ -721,7 +721,7 @@ Wie in MiNT. šbernimmt sowohl Dreaddir als auch Dxreaddir.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DHD][Der Directory-Handle-Deskriptor (DHD)]) * dhd
+(!link [DHD][Der Directory-Handle-Deskriptor (DHD!)]) * dhd
 !item [-> d0 =]
 long errcode
 !end_xlist
@@ -749,7 +749,7 @@ long errcode
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) *
+(!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) *
 !item [d0 =]
 int mode
 !item [-> d0 =]
@@ -809,7 +809,7 @@ weiter, auerdem werden ggf. XFS-Strukturen freigegeben.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) *
+(!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) *
 !item [-> d0 =]
 long errcode
 !end_xlist
@@ -833,7 +833,7 @@ Buchstaben 'A'..'Z' zugeordnet sind. Dieser Eintrag hat zwei Aufgaben:
       (!B)Achtung:(!b) Die root darf w„hrend der Lebensdauer eines
       gemounteten Dateisystems nicht freigegeben werden. Der Referenzz„hler
       der root sollte mit 1 vorbesetzt werden, um zu verhindern, da er per
-      free_DD freigegeben wird. In den Versionen vor (!nolink [MagiC]) 4.01 war dies
+      free_DD freigegeben wird. In den Versionen vor MagiC 4.01 war dies
       nicht notwendig, weil der Referenzz„hler (in unsauberer Weise) vor dem
       Aufruf von path2DD nicht inkrementiert und nachher dekrementier wurde.
 !item Beim wiederholten Zugriff ist (!nolink [d_xfs]) bereits initialisiert, und das XFS
@@ -868,7 +868,7 @@ weiter, d.h. alle DFS-Treiber werden durchprobiert.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name (ohne Pfad)
 !item [-> d0 =]
@@ -930,7 +930,7 @@ nicht verwendet. Also bitte nicht verwenden!
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name (ohne Pfad)
 !item [d0 =]
@@ -938,7 +938,7 @@ int omode (frs ™ffnen)
 !item [d1 =]
 int attrib (frs Erstellen)
 !item [-> d0 =]
-(!link [FD][Der Datei-Deskriptor (FD)]) *  oder Fehlercode
+(!link [FD][Der Datei-Deskriptor (FD!)]) *  oder Fehlercode
 !item [-> a0 =]
 SYMLINK *
 !end_xlist
@@ -988,7 +988,7 @@ gleichbedeutend mit O_WDENY.
 Die šberprfung der Zugriffsrechte obliegt vollst„ndig dem XFS, der Kernel
 tut nichts. Das w„re auch wenig sinnvoll, da jedes Dateisystem seine eigenen
 Mechanismen und Rechte hat. Zurckgegeben wird dem Kernel ein Zeiger auf
-einen ge”ffneten (!link [FD][Der Datei-Deskriptor (FD)]), d.h. das ™ffnen des Dateitreibers mu vom XFS
+einen ge”ffneten (!link [FD][Der Datei-Deskriptor (FD!)]), d.h. das ™ffnen des Dateitreibers mu vom XFS
 durchgefhrt werden. Der Referenzz„hler des zurckgegebenen FDs ist vom XFS
 zu erh”hen bzw. beim ersten ™ffnen auf 1 zu initialisieren. Fr symbolische
 Links und Diskwechsel gilt dasselbe wie bei xfs_sfirst.
@@ -1006,7 +1006,7 @@ Links und Diskwechsel gilt dasselbe wie bei xfs_sfirst.
 Dieses Verfahren ist sehr langwierig. DOS gibt beim Suchen der Datei bereits
 einen Zeiger auf den 32-Byte-Verzeichniseintrag zurck, der direkt zum
 šberprfen des Attributs und damit der Zugriffsrechte und auch zum ™ffnen
-der Datei dient. (!nolink [MagiC]) erwartet daher direkt die Implementation des
+der Datei dient. MagiC erwartet daher direkt die Implementation des
 Fopen-Befehls mit allen šberprfungen der Zugriffsrechte. Zurckgeliefert
 wird eine FD-Struktur, in die der Dateitreiber eingetragen und ge”ffnet
 wurde.
@@ -1032,7 +1032,7 @@ wurde.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [->]
 void
 !end_xlist
@@ -1070,7 +1070,7 @@ Referenzz„hler der root bei drv_open bereits auf 1.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) *d
+(!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) *d
 !item [-> d0 =]
 1L oder 0L
 !end_xlist
@@ -1133,9 +1133,9 @@ bei nachgeladenen XFSs nicht verwendet.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *olddir
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *olddir
 !item [a1 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *newdir
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *newdir
 !item [d0 =]
 char *oldname
 !item [d1 =]
@@ -1243,11 +1243,11 @@ es z.B. m”glich, den integrierten DOS-Treiber zu berladen.
 !item [d0 =]
 int mode
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *reldir akt. Verzeichnis
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *reldir akt. Verzeichnis
 !item [a1 =]
 char *pathname
 !item [-> d0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [d1 =]
 char *restpfad
 !item [oder]
@@ -1257,7 +1257,7 @@ ELINK
 !item [d1 =]
 Restpfad ohne beginnenden '\'
 !item  [a0 =]
-(!link [FD][Der Datei-Deskriptor (FD)]) des Pfades, in dem der symbolische Link
+(!link [FD][Der Datei-Deskriptor (FD!)]) des Pfades, in dem der symbolische Link
 liegt. Dies ist wichtig bei relativen Pfadangaben im Link.
 !item [a1 =]
 NULL, Der Pfad stellt den Parent des Wurzelverzeichnisses dar.
@@ -1300,7 +1300,7 @@ Der Pfadname, ohne Laufwerkbuchstaben und ohne fhrendes '\'.
 
 !begin_xlist !compressed [<a0]
 !item [<d0>]
-Zeiger auf den (!link [DD][Der Verzeichnis-Deskriptor (DD)]). Der Referenzz„hler des
+Zeiger auf den (!link [DD][Der Verzeichnis-Deskriptor (DD!)]). Der Referenzz„hler des
 DD wurde vom XFS um 1 erh”ht.
 !item [<d1>]
 Zeiger auf den restlichen Dateinamen ohne beginnenden '\' bzw. '/'. Wenn das
@@ -1391,7 +1391,7 @@ dekrementiert. šbergeben wird in a0 ein Zeiger auf einen Proze-Deskriptor.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name
 !item [d0 =]
@@ -1426,7 +1426,7 @@ Fr Freadlink. Wird vom DOS_XFS untersttzt.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name
 !item [d0 =]
@@ -1465,7 +1465,7 @@ diesem Fall ist name == NULL.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) * srchdir
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) * srchdir
 !item [a1 =]
 char *name (ohne Pfad)
 !item [d0 =]
@@ -1528,7 +1528,7 @@ unvorhersehbar!
 !item [a0 =]
 DTA *
 !item [a1 =]
-(!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) *
+(!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) *
 !item [-> d0 =]
 long errcode,
 !item [-> a0 =]
@@ -1561,7 +1561,7 @@ symbolischer Link auftreten.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) * dir
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) * dir
 !item [a1 =]
 char *name
 !item [d0 =]
@@ -1596,7 +1596,7 @@ untersttzt.
 !item [Parameter:]
 !begin_xlist !compressed [a0 =]
 !item [a0 =]
-(!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) *d
+(!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) *d
 !item [->]
 long errcode
 !end_xlist
@@ -1631,7 +1631,7 @@ einfach die gleichlautende DFS- Funktion auf.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name
 !item [-> d0 =]
@@ -1669,7 +1669,7 @@ Dwritelabel() aufgerufen.
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) *
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) *
 !item [a1 =]
 char *name
 !item [d0 =]
@@ -1712,12 +1712,12 @@ folge nicht (d.h. erstelle (!nolink [XATTR]) fr den Link)
 Bei der Arbeit mit einem XFS sind die folgenden Datenstrukturen wichtig:
 
 !begin_xlist [MX_DEV ] !compressed
-!item [(!link [DD] [Der Verzeichnis-Deskriptor (DD)])]        (Verzeichnis-Deskriptor)
-!item [(!link [DHD] [Der Directory-Handle-Deskriptor (DHD)])] (Directory-Handle-Deskriptor)
-!item [(!link [DMD] [Der Drive-Medium-Deskriptor (DMD)])]     (Medium-Deskriptor)
+!item [(!link [DD] [Der Verzeichnis-Deskriptor (DD!)])]        (Verzeichnis-Deskriptor)
+!item [(!link [DHD] [Der Directory-Handle-Deskriptor (DHD!)])] (Directory-Handle-Deskriptor)
+!item [(!link [DMD] [Der Drive-Medium-Deskriptor (DMD!)])]     (Medium-Deskriptor)
 !item [(!link [DTA] [Die Disk-Transfer-Area DTA])]            (Disk-Transfer-Area)
-!item [(!link [FD] [Der Datei-Deskriptor (FD)])]              (Datei-Deskriptor)
-!item [(!link [MX_DEV] [Der Ger„tetreiber (MX_DEV)])]         (Ger„tetreiber)
+!item [(!link [FD] [Der Datei-Deskriptor (FD!)])]              (Datei-Deskriptor)
+!item [(!link [MX_DEV] [Der Ger„tetreiber (MX_DEV!)])]         (Ger„tetreiber)
 !end_xlist
 
 Querverweis:
@@ -1766,7 +1766,7 @@ besten auf 1, s.o. bei xfs_drv_open) und bei jeder šbergabe an den Kernel
 (-> xfs_path2DD) um 1 inkrementiert werden.
 
 D.h. da xfs_path2DD beim Zurckgeben eines neuen
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]) (der also vom Kernel
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]) (der also vom Kernel
 sonst nicht referenziert wird) den Referenzz„hler auf 1 setzen mu.
 
 Wenn der Referenzz„hler ungleich 0 ist, hat der Kernel Zeiger auf diesen DD,
@@ -1807,7 +1807,7 @@ dhd_dmd:  DS.L   1   /* 0x00: Zeiger auf DMD  */
 
 Querverweis:
 (!link [XFS-Konzept in MagiC] [Das XFS-Konzept von MagiC]) ~
-(!link [DMD][Der Drive-Medium-Deskriptor (DMD)])
+(!link [DMD][Der Drive-Medium-Deskriptor (DMD!)])
 
 
 !begin_node dhd_dmd
@@ -1844,7 +1844,7 @@ Daten wie die Clustergr”e und die Anzahl der Sektoren ein.
 
 Querverweis:
 (!link [XFS-Konzept in MagiC] [Das XFS-Konzept von MagiC]) ~
-(!link [DD][Der Verzeichnis-Deskriptor (DD)])
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)])
 
 
 !begin_node d_xfs
@@ -1969,7 +1969,7 @@ Anforderung ausfhren muss.
 Die Dateideskriptoren mssen vom XFS angelegt und verwaltet werden. Alle
 Deskriptoren, die dem Kernel bekannt sind, haben Referenzz„hler ungleich
 Null. Fr den Kernel sieht ein FD genauso aus wie ein
-(!link [DD][Der Verzeichnis-Deskriptor (DD)]), weshalb im DOS_XFS
+(!link [DD][Der Verzeichnis-Deskriptor (DD!)]), weshalb im DOS_XFS
 die gleiche Datenstruktur verwendet wird.
 
 Fr den Kernel sieht ein FD folgendermaen aus, diese Eintr„ge mssen vom
@@ -2009,9 +2009,9 @@ fd_user2:    DS.L    1    /* 0x4c: zur freien Verfgung                */
 
 Querverweis:
 (!link [XFS-Konzept in MagiC] [Das XFS-Konzept von MagiC]) ~
-(!link [DMD][Der Drive-Medium-Deskriptor (DMD)]) ~
-(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)]) ~
-(!link [MX_DEV][Der Ger„tetreiber (MX_DEV)])
+(!link [DMD][Der Drive-Medium-Deskriptor (DMD!)]) ~
+(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)]) ~
+(!link [MX_DEV][Der Ger„tetreiber (MX_DEV!)])
 
 
 !begin_node fd_dmd
@@ -2269,14 +2269,14 @@ Querverweis:
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [FD][Der Datei-Deskriptor (FD)]) *file
+(!link [FD][Der Datei-Deskriptor (FD!)]) *file
 !item [-> d0 =]
 long errcode
 !end_xlist
 
 !item [Beschreibung:]
 Wenn fd_refcnt nicht schon 0 ist, mu fd_refcnt dekrementiert werden (dies
-mu vom (!link [MX_DEV][Der Ger„tetreiber (MX_DEV)]) erledigt werden). Bei dieser
+mu vom (!link [MX_DEV][Der Ger„tetreiber (MX_DEV!)]) erledigt werden). Bei dieser
 Gelegenheit sollten auch
 m”glicherweise vorhandene Puffer zurckgeschrieben bzw. Verzeichniseintr„ge
 aktualisiert werden. Wenn (!nolink [fd_refcnt]) 0 ist, kann der FD freigegeben werden.
@@ -2284,10 +2284,10 @@ Beim Diskwechsel ist (!nolink [fd_refcnt]) bereits beim Aufruf von dev_close 0, 
 FD mu einfach nur freigegeben werden.
 
 Der vom DOS_XFS installierte Dateitreiber schreibt die Verzeichnisdaten
-zurck und ruft dann den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertreiber auf.
+zurck und ruft dann den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])-Untertreiber auf.
 
 !item [Gruppe:]
-(!link [Ger„tetreiber][Der Ger„tetreiber (MX_DEV)])
+(!link [Ger„tetreiber][Der Ger„tetreiber (MX_DEV!)])
 
 !item [Querverweis:]
 ---
@@ -2300,13 +2300,13 @@ zurck und ruft dann den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertre
 !begin_node dev_datime
 
 (!B)Fr Fdatime.(!b) Der vom DOS_XFS installierte Dateitreiber leitet den
-Aufruf an den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertreiber weiter, wenn die Funktion im
+Aufruf an den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])-Untertreiber weiter, wenn die Funktion im
 MX_DDEV-Treiber untersttzt wird (Zeiger != NULL), ansonsten wird die
 Funktion (!I)automatisch(!i) mit Hilfe der Daten des FD ausgefhrt.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 a1 !! = !! int d[2]
 d0 !! = !! int setflag
 -> d0 !! = !! long errcode
@@ -2325,7 +2325,7 @@ d0 !! = !! int setflag
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [FD][Der Datei-Deskriptor (FD)]) *file
+(!link [FD][Der Datei-Deskriptor (FD!)]) *file
 !item [d0 =]
 int mode
 !item [-> d0 =]
@@ -2351,12 +2351,12 @@ Bit 1 gesetzt: Eingabe wird ge-echo-t
 !end_xlist
 
 Der vom DOS_XFS installierte Dateitreiber leitet den Aufruf an den
-(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertreiber weiter, wenn die Funktion im MX_DDEV-Treiber
+(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])-Untertreiber weiter, wenn die Funktion im MX_DDEV-Treiber
 untersttzt wird (Zeiger != NULL), ansonsten wird die Funktion automatisch
 auf dev_fread zurckgefhrt.
 
 !item [Gruppe:]
-(!link [Ger„tetreiber][Der Ger„tetreiber (MX_DEV)])
+(!link [Ger„tetreiber][Der Ger„tetreiber (MX_DEV!)])
 
 !item [Querverweis:]
 ---
@@ -2371,14 +2371,14 @@ auf dev_fread zurckgefhrt.
 (!B)Fr zeilenorientierte Eingabe(!b). <mode> wie in dev_getc. Zurckgegeben
 wird die Anzahl der eingegebenen Zeichen ohne Endezeichen o.„. Der vom
 DOS_XFS installierte Dateitreiber leitet den Aufruf an den
-(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertreiber weiter, wenn die Funktion im MX_DDEV-Treiber
+(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])-Untertreiber weiter, wenn die Funktion im MX_DDEV-Treiber
 untersttzt wird (Zeiger != NULL), ansonsten wird die Funktion automatisch
 auf dev_fread zurckgefhrt, die Zeile wird dann mit CR und LF beendet,
 Steuerzeichen (BS oder Del) nicht ausgewertet.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 a1 !! = !! char *buf
 d1 !! = !! long size
 d0 !! = !! int mode
@@ -2391,14 +2391,14 @@ d0 !! = !! int mode
 !begin_node dev_ioctl
 
 (!B)Fr Fcntl.(!b) Der vom DOS_XFS installierte Dateitreiber leitet den
-Aufruf direkt an den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertreiber weiter. Bearbeitet werden jedoch
+Aufruf direkt an den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])-Untertreiber weiter. Bearbeitet werden jedoch
 vorher folgende Funktionen: FSTAT und FUTIME. Diese sollten auch von anderen
 XFSs ausgefhrt werden. Jeder Dateitreiber sollte (!B)FIONREAD(!b) und
 (!B)FIONWRITE(!b) untersttzen.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 d0 !! = !! int cmd
 a1 !! = !! void *buf
 -> d0 !! = !! long errcode
@@ -2417,7 +2417,7 @@ a1 !! = !! void *buf
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [FD][Der Datei-Deskriptor (FD)]) *file
+(!link [FD][Der Datei-Deskriptor (FD!)]) *file
 !item [d0 =]
 int mode
 !item [d1 =]
@@ -2442,12 +2442,12 @@ Bit 0 nicht gesetzt: "raw" Modus
 !end_xlist
 
 Der vom DOS_XFS installierte Dateitreiber leitet den Aufruf an den
-(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertreiber weiter, wenn die Funktion im MX_DDEV-Treiber
+(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])-Untertreiber weiter, wenn die Funktion im MX_DDEV-Treiber
 untersttzt wird (Zeiger != NULL), ansonsten wird die Funktion automatisch
 auf dev_fwrite zurckgefhrt.
 
 !item [Gruppe:]
-(!link [Ger„tetreiber][Der Ger„tetreiber (MX_DEV)])
+(!link [Ger„tetreiber][Der Ger„tetreiber (MX_DEV!)])
 
 !item [Querverweis:]
 ---
@@ -2462,11 +2462,11 @@ auf dev_fwrite zurckgefhrt.
 Von Datei <file> werden <count> Bytes in den Puffer <buffer> gelesen. Die
 Anzahl der tats„chlich gelesenen Zeichen wird zurckgegeben. Der vom DOS_XFS
 installierte Dateitreiber leitet den Aufruf direkt an den
-(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertreiber weiter.
+(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])-Untertreiber weiter.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 d0 !! = !! long count
 a1 !! = !! char *buffer
 -> d0 !! = !! long amount
@@ -2480,11 +2480,11 @@ a1 !! = !! char *buffer
 (!B)Fr Fseek.(!b) <mode> ist, wie im TOS, 0, 1 oder 2. Zurckgegeben wird
 die aktuelle Position des Schreib-/Lesezeigers, Ger„tetreiber mssen hier
 immer eine 0L zurckgeben. Der vom DOS_XFS installierte Dateitreiber leitet
-den Aufruf direkt an den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertreiber weiter.
+den Aufruf direkt an den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])-Untertreiber weiter.
 
 (!B)Parameter-bergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 d0 !! = !! long where
 d1 !! = !! int mode
 -> d0 !! = !! long position
@@ -2503,7 +2503,7 @@ d1 !! = !! int mode
 !item [Parameter:]
 !begin_xlist !compressed [-> a0 =]
 !item [a0 =]
-(!link [FD][Der Datei-Deskriptor (FD)]) *file
+(!link [FD][Der Datei-Deskriptor (FD!)]) *file
 !item [a1 =]
 MAGX_UNSEL *unselect oder NULL
 !item [d0 =]
@@ -2569,7 +2569,7 @@ folgendermaen vor:(!b)
 !item  unselect mit der Adresse der Aufr„umroutine und einem optionalen
        Parameter initialisieren, Prototyp etwa:
 !begin_verbatim
-void unselect( a0 = MAGX_UNSEL *un,a1 = void *ap_code );
+void unselect( a0 = MAGX_UNSEL *un, a1 = void *ap_code );
 !end_verbatim
 !item Interrupt zum Aufwecken installieren, diesem unselect (und damit auch
       den optionalen Parameter) und appl mitteilen.
@@ -2612,10 +2612,10 @@ dev_stat aufgerufen. In diesem Fall kann die Aussage getroffen werden
 "Zeichen liegt an" (Wert == 1) bzw. "kein Zeichen liegt an" (Wert == 0).
 
 Der vom DOS_XFS installierte Dateitreiber leitet den Aufruf direkt an den
-(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertreiber weiter.
+(!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])-Untertreiber weiter.
 
 !item [Gruppe:]
-(!link [Ger„tetreiber][Der Ger„tetreiber (MX_DEV)])
+(!link [Ger„tetreiber][Der Ger„tetreiber (MX_DEV!)])
 
 !item [Querverweis:]
 ---
@@ -2630,11 +2630,11 @@ Der vom DOS_XFS installierte Dateitreiber leitet den Aufruf direkt an den
 Auf Datei <file> werden <count> Bytes aus dem Puffer <buffer> geschrieben.
 Die Anzahl der tats„chlich geschriebenen Zeichen wird zurckgegeben. Der vom
 DOS_XFS installierte Dateitreiber aktualisiert Zeit und Datum der Datei und
-leitet dann den Aufruf an den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV)])-Untertreiber weiter.
+leitet dann den Aufruf an den (!link [MX_DDEV][Der Ger„tetreiber (MX_DDEV!)])-Untertreiber weiter.
 
 (!B)Parameter-šbergabe:(!b)
 !begin_table [r l l]
-a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD)]) *file
+a0 !! = !! (!link [FD][Der Datei-Deskriptor (FD!)]) *file
 d0 !! = !! long count
 a1 !! = !! char *buffer
 -> d0 !! = !! long amount
@@ -2665,7 +2665,7 @@ Die Deinstallation eines XFS ist (!I)nicht(!i) vorgesehen.
 !begin_node Kernelfunktionen fr ein XFS
 !label XFS, Kernelfunktionen fr ein
 
-(!nolink [MagiC]) stellt den installierten XFSs, DFSs oder Ger„tetreibern einige
+MagiC stellt den installierten XFSs, DFSs oder Ger„tetreibern einige
 Kernelinformationen sowie -funktionen zur Verfgung. Bei den
 Kernelfunktionen gilt dieselbe Registerkonvention wie fr die
 XFS-Funktionen, d.h. d0-d2 und a0-a2 k”nnen zerst”rt werden. Einen Zeiger

--- a/magic/magicinf.u
+++ b/magic/magicinf.u
@@ -28,7 +28,7 @@ graphics mode. (!B)Warning:(!b) One should only place programs here
 that are moderate in their memory usage; if one loads, say,
 WORDPLUS in this manner then no other program can be loaded
 any more unless one had limited its memory hunger by using
-LIMITMEM.TTP (a utility supplied with (!nolink [MagiC])).
+LIMITMEM.TTP (a utility supplied with MagiC).
 
 !label #_AUT
 !item [#_AUT]
@@ -50,7 +50,7 @@ here 0x70 is the fill-pattern (7=fully filled) and 8 is the
 colour. Thus the code corresponds to the value that sets the
 appearance of a filled rectangle in the (!nolink [AES]) object G_BOX.
 
-From (!nolink [MagiC]) 5.20 onwards.
+From MagiC 5.20 onwards.
 
 !label #_BUF
 !item [#_BUF]
@@ -63,8 +63,8 @@ the data can be saved.
 
 !label #_CTR
 !item [#_CTR]
-This entry marks the end of the (!nolink [MagiC]) variables, and serves
-as an identifier that the following data (of the (!nolink [control])
+This entry marks the end of the MagiC variables, and serves
+as an identifier that the following data (of the control
 field or desktop) are adopted directly in the shell buffer.
 
 !label #_DEV
@@ -75,12 +75,12 @@ a resolution change. If the (!nolink [VDI]) returns an error-code on
 opening of the workstation, then a re-start will be made
 with device number 1 (current resolution).
 The usual resolutions of ST/TT are:
-!begin_table[l l l]
+!begin_table [l l l]
 2 = ST-Low,    !!  3 = ST-Medium, !! 4 = ST-High
 6 = TT-Medium, !!  8 = TT-High,   !! 9 = TT-Low
 !end_table
 Further ones depend on the device drivers that were declared
-in the ASSIGN.SYS file. As of (!nolink [MagiC]) 4, the above-mentioned
+in the ASSIGN.SYS file. As of MagiC 4, the above-mentioned
 number must be followed by a further one that describes the
 Falcon030 resolution modes. This second number (!I)must(!i) be
 included, as otherwise the MAGX.INF file will not be read.
@@ -101,40 +101,40 @@ no #_ENV line has been entered.
 
 !label #_FLG
 !item [#_FLG]
-Determines various (!nolink [MagiC]) settings. The value included here
+Determines various MagiC settings. The value included here
 is taken to be a bit-vector, and interpreted as follows:
 !begin_xlist !compressed [Bit-0 =]
 !item [Bit-0 =]
-Position of the (!nolink [MagiC]) logo (set ==> left); (!nl)
+Position of the MagiC logo (set ==> left); (!nl)
 from Mag!x 2.0 onwards
 
 !item [Bit-1 =]
 Activation of the 3D-look (set ==> 3D off); (!nl)
-from (!nolink [MagiC]) 3.0 onwards
+from MagiC 3.0 onwards
 
 !item [Bit-2 =]
 Display Backdrop button? (set ==> no); (!nl)
-from (!nolink [MagiC]) 3.0 onwards
+from MagiC 3.0 onwards
 
 !item [Bit-3 =]
 Window name in 3D-look? (set ==> no); (!nl)
-from (!nolink [MagiC]) 4.0 onwards
+from MagiC 4.0 onwards
 
 !item [Bit-4 =]
 3D font in window title? (set ==> no); (!nl)
-from (!nolink [MagiC]) 4.0 onwards
+from MagiC 4.0 onwards
 
 !item [Bit-5 =]
 Use realtime scrolling? (set ==> no); (!nl)
-from (!nolink [MagiC]) 4.02 onwards
+from MagiC 4.02 onwards
 
 !item [Bit-6 =]
 Use realtime sizing and moving? (set ==> no); (!nl)
-from (!nolink [MagiC]) 5.10 onwards
+from MagiC 5.10 onwards
 
 !item [Bit-7 =]
 Use 3D menus? (set ==> yes); (!nl)
-from (!nolink [MagiC]) 6.00 onwards
+from MagiC 6.00 onwards
 
 !end_xlist
 (!B)Note:(!b) If this entry is missing then all flags will be taken
@@ -144,13 +144,13 @@ by a short click on the name field of an (!I)active(!i) window.
 
 !label #_FSL
 !item [#_FSL]
-This entry allows settings for (!nolink [MagiC])'s file-selector. First
+This entry allows settings for MagiC's file-selector. First
 comes a flag which is ignored at present and so should be 0.
 Next follows a character string of possible file-type masks,
 separated by ';'. Double masks are separated from each other
 by ',' (e.g. '*.PRG,*.APP' or '*.JPG,*.JPEG').
 
-From (!nolink [MagiC]) 5.10 onwards.
+From MagiC 5.10 onwards.
 
 !label #_HDV
 !item [#_HDV]
@@ -168,7 +168,7 @@ represent in turn:
 !item [monoFlag]	1 (equidistant) or 0 (proportional)
 !item [fontH]	Font height for vst_height
 !end_xlist
-From (!nolink [MagiC]) 6.00 onwards.
+From MagiC 6.00 onwards.
 
 !label #_MAG
 !item [#_MAG]
@@ -177,12 +177,12 @@ This entry is reserved, and currently serves as a pure comment.
 !label #_OBS
 !item [#_OBS]
 The height of a resource unit of measure can be set as of
-(!nolink [MagiC]) 5.20 independently of the large (!nolink [AES]) font. Specially
+MagiC 5.20 independently of the large (!nolink [AES]) font. Specially
 with vector fonts one should enter a fixed 8*16 raster here
 so as not to confuse user programs. (!nl)
 Syntax: #_OBS <horizontal raster> <vertical raster> 0 0
 
-From (!nolink [MagiC]) 5.20 onwards.
+From MagiC 5.20 onwards.
 
 !label #_SCP
 !item [#_SCP]
@@ -210,7 +210,7 @@ the libraries do not have to be specially loaded in; this
 is sensible if one has sufficient memory or a slow storage
 medium (loading in of an SLB costs time).
 
-From (!nolink [MagiC]) 6.00 onwards.
+From MagiC 6.00 onwards.
 
 !label #_TRM
 !item [#_TRM]
@@ -244,14 +244,14 @@ From Mag!x 2.0 onwards.
 !label #_TXB
 !item [#_TXB]
 !item [#_TXS]
-From (!nolink [MagiC]) 5.20 onwards, the font and its height may be set
+From MagiC 5.20 onwards, the font and its height may be set
 separately for the small and large (!nolink [AES]) font. One (!I)has to(!i)
 specify here whether the font is proportional or monospaced.
-Proportional fonts work as of (!nolink [MagiC]) 6. Syntax for the large(!nl)
+Proportional fonts work as of MagiC 6. Syntax for the large(!nl)
 font is: #_TXB <fontID> <monoFlag> <pixelHeight>, and for
 the small font: #_TXS <fontID> <monoFlag> <pixelHeight>.
 
-As of (!nolink [MagiC]) 5.20.
+As of MagiC 5.20.
 
 !label #_TXT
 !item [#_TXT]
@@ -261,7 +261,7 @@ The font height is set by the (!nolink [AES]) with vst_height; a height
 of 0 denotes standard settings; font ID 1 is the system font.
 
 As of Mag!X 2.0, additional parameter; no longer present
-from (!nolink [MagiC]) 6.00 onwards.
+from MagiC 6.00 onwards.
 
 
 !label #_WND
@@ -281,7 +281,7 @@ this command; the lines relevant to the (!nolink [AES]) all start with
 identifier is not found, then one will be assumed implicitly
 before the first line.
 
-From (!nolink [MagiC]) 5.01 onwards.
+From MagiC 5.01 onwards.
 
 
 !item [#[boot!]]
@@ -291,12 +291,12 @@ includes the number of cookies, the log-file, and tiles
 plus logo image to be used for the background during booting
 (see below).
 
-From (!nolink [MagiC]) 6.00 onwards.
+From MagiC 6.00 onwards.
 
 !item [#[shelbuf!]]
 With this section identifier, the (!nolink [AES]) section ends.
 
-From (!nolink [MagiC]) 6.00 onwards.
+From MagiC 6.00 onwards.
 
 !item [#[vfat!]]
 With this entry one can specify the drives that are to
@@ -309,18 +309,18 @@ drive specified in this way an unmount is perfomed first,
 so that it is possible to use long filenames on boot drives
 as well.
 
-From (!nolink [MagiC]) 5.01 onwards.
+From MagiC 5.01 onwards.
 
 !item [aux]
 The (!nolink [GEMDOS]) standard files can now be redirected also to
 (!nolink [BIOS]) devices that lie in u:\dev: (!B)Example:(!b) aux=u:\dev\modem
 
-As of (!nolink [MagiC]) 6.20.
+As of MagiC 6.20.
 
 !item [biosdev]
 Definition of the (!nolink [BIOS]) devices. As without changes to the
 MAGX.INF a few filenames in u:/dev will be missing from
-(!nolink [MagiC]) 6.20 onwards, herewith a few examples for various
+MagiC 6.20 onwards, herewith a few examples for various
 computer types that are to be inserted:
 !begin_verbatim
 Atari ST:
@@ -349,47 +349,47 @@ Mac:
 (None)
 !end_verbatim
 
-As of (!nolink [MagiC]) 6.20.
+As of MagiC 6.20.
 
 !item [cookie]
 Determines the number of cookies in the cookie jar. By
 default at least 20 cookies are always (!nolink [installed]).
 
-From (!nolink [MagiC]) 6.00 onwards.
+From MagiC 6.00 onwards.
 
 !item [con]
 The (!nolink [GEMDOS]) standard files can now be redirected also to (!nolink [BIOS])
 devices that lie in u:\dev: (!B)Example:(!b) con=u:\dev\console
 
-As of (!nolink [MagiC]) 6.20.
+As of MagiC 6.20.
 
 !item [image]
 Draws a logo in the centre of the screen.
 
-From (!nolink [MagiC]) 6.00 onwards.
+From MagiC 6.00 onwards.
 
 !item [log]
 The (!nolink [BIOS]) outputs of the AUTO folder are intercepted and
 written to the specified log-file. You can also put
 u:\dev\null here in order to suppress the output completely.
 
-From (!nolink [MagiC]) 6.00 onwards.
+From MagiC 6.00 onwards.
 
 !item [prn]
 The (!nolink [GEMDOS]) standard files can now be redirected also to
 (!nolink [BIOS]) devices that lie in u:\dev: (!B)Example:(!b) prn=u:\dev\prn
 
-As of (!nolink [MagiC]) 6.20.
+As of MagiC 6.20.
 
 !item [titel]
 Before executing the AUTO folder, the screen can be tiled first.
 
-From (!nolink [MagiC]) 6.00 onwards.
+From MagiC 6.00 onwards.
 
 !end_xlist
 
 (!B)Note:(!b) Lines starting with a semicolon are ignored, and so can be
-used for (!I)comments.(!i) From (!nolink [MagiC]) 5 onwards, a faulty line found when
+used for (!I)comments.(!i) From MagiC 5 onwards, a faulty line found when
 evaluating the MAGX.INF file will be displayed on the screen; but as
 the (!nolink [AES]) has not yet been initialized at this point in time, the
 output cannot be made to a dialog box.
@@ -530,7 +530,7 @@ ausgewertet, wenn das System fÅr einen Auflîsungswechsel gerade neu
 gestartet wird. Gibt das VDI beim ôffnen der Workstation einen Fehlercode
 zurÅck, so wird es noch einmal mit GerÑtenummer 1 (aktuelle Auflîsung)
 gestartet. Die Åblichen Auflîsungen von ST/TT sind:
-!begin_table[l l l]
+!begin_table [l l l]
 2 = ST niedrig, !! 3 = ST mittel, !! 4 = ST hoch
 6 = TT mittel,  !! 8 = TT hoch,   !! 9 = TT niedrig
 !end_table
@@ -559,44 +559,44 @@ Legt verschiedene Einstellungen von MagiC fest. Der hier stehende Wert wird
 als Bitvektor aufgefaût, und wie folgt interpretiert:
 !begin_xlist !compressed [Bit-0 =]
 !item [Bit-0 =]
-Position des (!nolink [MagiC])-Logos     (gesetzt ==> links)
+Position des MagiC-Logos     (gesetzt ==> links)
 
 ab Mag!X 2.0
 
 !item [Bit-1 =]
 Aktivierung des 3D-Looks     (gesetzt ==> 3D aus)
 
-ab (!nolink [MagiC]) 3.0
+ab MagiC 3.0
 
 !item [Bit-2 =]
 Backdrop Button zeigen ?     (gesetzt ==> nein)
 
-ab (!nolink [MagiC]) 3.0
+ab MagiC 3.0
 
 !item [Bit-3 =]
 Fensternamen im 3D-Look?     (gesetzt ==> nein)
 
-ab (!nolink [MagiC]) 4.0
+ab MagiC 4.0
 
 !item [Bit-4 =]
 3D-Schrift im Fenstertitel?  (gesetzt ==> nein)
 
-ab (!nolink [MagiC]) 4.0
+ab MagiC 4.0
 
 !item [Bit-5 =]
 Echzeit-Scrolling benutzen?  (gesetzt ==> nein)
 
-ab (!nolink [MagiC]) 4.02
+ab MagiC 4.02
 
 !item [Bit-6 =]
 Echzeitvergîûern und -verschieben benutzen?  (gesetzt ==> nein)
 
-ab (!nolink [MagiC]) 5.10
+ab MagiC 5.10
 
 !item [Bit-7 =]
 3D-MenÅs benutzen?           (gesetzt ==> ja)
 
-ab (!nolink [MagiC]) 6.00
+ab MagiC 6.00
 
 !end_xlist
 (!B)Hinweis:(!b) Fehlt dieser Eintrag, so werden alle Flags als 0
@@ -612,7 +612,7 @@ wird und daher immer Null sein sollte. Es folgt eine Zeichenkette
 mîglicher Dateitypen, die durch ';' getrennt sind. Doppelmuster werden
 voneinander durch ',' getrennt (z.B. "*.PRG,*.APP" oder "*.JPG,*.JPEG").
 
-ab (!nolink [MagiC]) 5.10
+ab MagiC 5.10
 
 !label #_HDV
 !item [#_HDV]
@@ -629,7 +629,7 @@ Hiermit kann man das Aussehen der INFO-Zeile aller Fenster Ñndern
 !item [fontH]	Zeichensatzhîhe fÅr vst_height()
 !end_xlist
 
-ab (!nolink [MagiC]) 6.00
+ab MagiC 6.00
 
 !label #_MAG
 !item [#_MAG]
@@ -638,13 +638,13 @@ Kommentar.
 
 !label #_OBS
 !item [#_OBS]
-Die Hîhe einer Ressource-Einheit lÑût sich ab (!nolink [MagiC]) 5.20 unabhÑngig vom
+Die Hîhe einer Ressource-Einheit lÑût sich ab MagiC 5.20 unabhÑngig vom
 groûen AES-Zeichensatz festlegen. Insbesondere bei Vektorfonts sollte hier
 ein festes Raster von 8*16 eingetragen werden, um Anwenderprogramme nicht
 zu verwirren. (!nl)
 Syntax: #_OBS <horiz.Raster> <vertik.Raster> 0 0
 
-ab (!nolink [MagiC]) 5.20
+ab MagiC 5.20
 
 !label #_SCP
 !item [#_SCP]
@@ -669,7 +669,7 @@ d.h. wenn ein Programm Slbopen() aufruft, brauchen die Bibliotheken nicht
 extra nachgeladen zu werden. Sinnvoll, wenn man genÅgend Speicher oder
 ein langsames Speichermedium hat (das Nachladen einer SLB kostet Zeit).
 
-ab (!nolink [MagiC]) 6.00
+ab MagiC 6.00
 
 !label #_TRM
 !item [#_TRM]
@@ -699,15 +699,15 @@ ab Mag!X 2.0
 !label #_TXB
 !item [#_TXB]
 !item [#_TXS]
-Zeichensatz und -hîhe lassen sich ab (!nolink [MagiC]) 5.20 fÅr den kleinen und den
+Zeichensatz und -hîhe lassen sich ab MagiC 5.20 fÅr den kleinen und den
 groûen AES-Zeichensatz getrennt einstellen. Hier muû unbedingt angegeben
 werden, ob der Zeichensatz proportional oder Ñquidistant ist.
-Proportionale ZeichensÑtze funktionieren ab (!nolink [MagiC]) 6.
+Proportionale ZeichensÑtze funktionieren ab MagiC 6.
 Syntax (!nl)
 fÅr den groûen Zeichensatz: #_TXB <fontID> <monoFlag> <pixelHîhe> (!nl)
 fÅr den kleinen Zeichensatz: #_TXS <fontID> <monoFlag> <pixelHîhe> (!nl)
 
-ab (!nolink [MagiC]) 5.20
+ab MagiC 5.20
 
 !label #_TXT
 !item [#_TXT]
@@ -716,7 +716,7 @@ lautet: <Hîhe groûer Font> <Hîhe kleiner Font> <Font-ID> Die Zeichenhîhe
 wird vom AES per vst_height gesetzt; Hîhen von 0 bedeuten
 Standardeinstellungen; Font-ID 1 ist der Systemzeichensatz.
 
-ab Mag!X 2.0, zusÑtzlicher Parameter; nicht mehr vorhanden ab (!nolink [MagiC]) 6.00
+ab Mag!X 2.0, zusÑtzlicher Parameter; nicht mehr vorhanden ab MagiC 6.00
 
 
 !label #_WND
@@ -734,18 +734,18 @@ Mit der auf diesen Befehl folgenden Zeile beginnen die Informationen fÅr das
 Wird diese Abschnittskennung nicht gefunden, so wird implizit eine
 solche vor der ersten Zeile angenommen.
 
-ab (!nolink [MagiC]) 5.01
+ab MagiC 5.01
 
 
 !item [#[boot!]]
 Dier Werte ab dieser Abschnittkennung werden vor den Start des (!nolink [AES]) ausgewertet.
 
-ab (!nolink [MagiC]) 6.00
+ab MagiC 6.00
 
 !item [#[shelbuf!]]
 Mit dieser Abschnittkennung endet der AES-Abschnitt.
 
-ab (!nolink [MagiC]) 6.00
+ab MagiC 6.00
 
 !item [#[vfat!]]
 Mit diesem Eintrag kînnen diejenigen Laufwerke festgelegt werden, die lange
@@ -757,14 +757,14 @@ Auflistung der Laufwerke, die die langen Dateinamen unterstÅtzen sollen.
 ein Unmount durchgefÅhrt, so daû es mîglich ist, die langen Dateinamen auch
 auf dem Bootlaufwerk zu benutzen.
 
-ab (!nolink [MagiC]) 5.01
+ab MagiC 5.01
 
 !item [aux]
 Die GEMDOS-Standarddateien lassen sich jetzt auch auf
 BIOS-GerÑte umlenken, die in u:\dev liegen:
 aux=u:\dev\modem
 
-ab (!nolink [MagiC]) 6.20
+ab MagiC 6.20
 
 !item [biosdev]
 Festlegung der BIOS-GerÑte.
@@ -798,50 +798,50 @@ Mac:
 (keine)
 !end_verbatim
 
-ab (!nolink [MagiC]) 6.20
+ab MagiC 6.20
 
 !item [cookie]
 Legt die Anzahl der Cookies im Cookie-Jar fest. StandardmÑûig werden immer 
 mindestens 20 Cookies angelegt.
 
-ab (!nolink [MagiC]) 6.00
+ab MagiC 6.00
 
 !item [con]
 Die (!nolink [GEMDOS])-Standarddateien lassen sich jetzt auch auf
 (!nolink [BIOS])-GerÑte umlenken, die in u:\dev liegen:
 con=u:\dev\console
 
-ab (!nolink [MagiC]) 6.20
+ab MagiC 6.20
 
 !item [image]
 Ausgabe eines Logos, das zentriert dargestellt wird.
 
-ab (!nolink [MagiC]) 6.00
+ab MagiC 6.00
 
 !item [log]
 Die (!nolink [BIOS])-Ausgaben des AUTO-Ordners werden abgefangen in und die angegebe
 Datei geschrieben.
 
-ab (!nolink [MagiC]) 6.00
+ab MagiC 6.00
 
 !item [prn]
 Die (!nolink [GEMDOS])-Standarddateien lassen sich jetzt auch auf
 (!nolink [BIOS])-GerÑte umlenken, die in u:\dev liegen:
 prn=u:\dev\prn
 
-ab (!nolink [MagiC]) 6.20
+ab MagiC 6.20
 
 !item [titel]
 Vor AusfÅhren des AUTO Ordners kann der Bildschirm zunÑchst gekachelt werden.
 
-ab (!nolink [MagiC]) 6.00
+ab MagiC 6.00
 
 
 
 !end_xlist
 
 (!B)Hinweis:(!b) Zeilen die mit einem Semikolon beginnen werden ignoriert,
-und kînnen deshalb fÅr (!I)Kommentarzwecke(!i) benutzt werden. Ab (!nolink [MagiC]) 5
+und kînnen deshalb fÅr (!I)Kommentarzwecke(!i) benutzt werden. Ab MagiC 5
 wird eine fehlerhafte Zeile beim Auswerten der 'magx.inf'-Datei auf dem
 Bildschirm dargestellt; da das (!nolink [AES]) zu diesem Zeitpunkt aber noch nicht
 initialisiert ist, kann die Ausgabe nicht in einer Dialogbox erfolgen.

--- a/protokol/ssp/ssp.u
+++ b/protokol/ssp/ssp.u
@@ -1,7 +1,7 @@
 !begin_node System Services Protocol (SSP)
 
 
-The purpose of the System (!nolink [Services]) protocol (SSP) is described in
+The purpose of the System Services Protocol (SSP) is described in
 'What is SSP?'
 
 (!B)Planning phase (!b)
@@ -71,7 +71,7 @@ application requested a service (SRA simulation).
 SRA programmers: You'll have display in the same dialog window showing
 different requests coming in, and the Server will simulate being an
 SPA and sending back acknowledgement (SPA simulation) including
-simulation of (!nolink [Service]) Initialization and DRS delays.
+simulation of Service Initialization and DRS delays.
 
 The debug modes will not be available in the first official release
 version, to keep the Server code small and efficient.
@@ -85,10 +85,10 @@ somebody else, so that we can keep track of things and I can send
 updates to everybody.
 
 (!B)Target for V1.0 is an as complete as possible spec of Send File,
-Display (!nolink [Message]), Send (!nolink [Message]), Status Display, Context (!nolink [Popup]), Compress
+Display Message, Send Message, Status Display, Context Popup, Compress
 File and Display Information Services.(!b)
 
-These are the (!nolink [services][Services]) that will be primarily used by the currently
+These are the services that will be primarily used by the currently
 involved applications.
 
 Changes to the spec will be listed on the 'SSP changes' page.
@@ -138,7 +138,7 @@ Specification changes as of Nov. 7th, 2000
 !begin_itemize
 !item updated spec version number to V0.8
 
-!item Added the first (!link [constant definitions][Defines (SSP)]) including a short
+!item Added the first (!link [constant definitions][Defines (SSP!)]) including a short
 explanation of the determintation of services on Server side as reaction to SSP_SRASR
 and its data identification.
 
@@ -174,7 +174,7 @@ this...
 
 !item Added SSP message pipeline scheme to make the way it works more transparent ;)
 
-!item Changed Context (!nolink [Popup]) Service spec to including mouse
+!item Changed Context Popup Service spec to including mouse
 parameters into the SSP_SRASR and SSP_SSIR messages
 
 !item Added (!link [Information Display Service][SSP_DISPLAYINFO]) in conjunction
@@ -196,7 +196,7 @@ each of the apps
 !item SSP_SRASR: changed and updated data type spec for SRA service request
 
 !item Added handling of folder names to the send file, upload file and compress file
-service specs in (!nolink [Services]), SSP_SENDFILE, SSP_UPLOADFILE, and SSP_COMPRESSFILE,
+service specs in Services, SSP_SENDFILE, SSP_UPLOADFILE, and SSP_COMPRESSFILE,
 see the service implementation notes.
 
 !item Decided to implement SSP into a text editor shared/static library under
@@ -217,30 +217,30 @@ useable throughout the whole system. All applications are targeted,
 although networking applications will probably benefit most quickly.
 SSP is a Client-Server architecture. The SSP-Server (background
 application) has globally registered applications providing different
-services (service providing applications or SPAs). (!nolink [Service]) Requesting
+services (service providing applications or SPAs). Service Requesting
 Applications ((!link [SRA][SRA])s) can use the SPA's services for their own
 documents.
 
 (!B)Example:(!b)
 !begin_itemize !compressed
 !item User opens popup by right clicking into an image in Smurf
-!item User chooses 'System (!nolink [Services])' in the popup and another popup
+!item User chooses 'System Services' in the popup and another popup
 !item with all possible services opens (provided by the SSP-Server)
 !item User chooses 'Send file' and another popup with registered Send
-     File (!nolink [Service]) applications opens (provided by (!nolink [SSP-Server]))
+     File Service applications opens (provided by SSP-Server)
 !item User chooses for example AtarICQ
-!item Smurf sends (!nolink [Service Initialization]) Request (SIR) for Send File
-     and chosen SPA (AtarICQ) to (!nolink [SSP-Server])
-!item nolink [SSP-Server]), if necessary, starts AtarICQ and sends Send File SIR
+!item Smurf sends Service Initialization Request (SIR) for Send File
+     and chosen SPA (AtarICQ) to SSP-Server
+!item SSP-Server, if necessary, starts AtarICQ and sends Send File SIR
      along with request for list of possible recipients
-!item AtarICQ sends list of online users to (!nolink [SSP-Server])
-!item nolink [SSP-Server]) opens popup with possible recipients
+!item AtarICQ sends list of online users to SSP-Server
+!item SSP-Server opens popup with possible recipients
 !item User chooses one
-!item Server sends (!nolink [Service]) Use Request (SUR) for Send File service to
+!item Server sends Service Use Request (SUR) for Send File service to
      SPA (aICQ)
 !item aICQ opens connection to recipient and sends image file
-!item aICQ confirms the Server with SPA (!nolink [Service]) Acknowledge (SPASA)
-!item Server confirms Smurf with Server (!nolink [Service]) Acknowledge (SSA)
+!item aICQ confirms the Server with SPA Service Acknowledge (SPASA)
+!item Server confirms Smurf with Server Service Acknowledge (SSA)
 !end_itemize
 
 Possible services and registered applications are held in different
@@ -249,9 +249,9 @@ be registered, it can be done at the first communication between the
 SSP-Server and the application, or pre-use, by the application
 installer or config program. The first possibility is for convenience
 to the user, because simply copying and using a new version of a
-program would not corrupt the registration with the (!nolink [SSP-Server]), since
+program would not corrupt the registration with the SSP-Server, since
 the application would register itself with the Server at startup.
-Registering with the (!nolink [SSP-Server]) consists of a short communication in
+Registering with the SSP-Server consists of a short communication in
 which the program path and name of the SPA and the provided services
 are sent to the Server. The Server could runtime (when services are
 requested by the SRA) check for the existence of registered SPAs,
@@ -260,7 +260,7 @@ which will prevent errors upon service initialization.
 !label What is the SSP-Server?
 What is the SSP-Server?
 
-The (!nolink [SSP-Server]) is an application running in the background that
+The SSP-Server is an application running in the background that
 manages all communication between SRAs and SPAs. All (!link [services][Services]) are
 hardwired into the Server. This system has been chosen for several
 reasons:
@@ -278,11 +278,11 @@ reasons:
      introduction of new services
 
 !item The Server can combine different services into one, for example
-     Compress File (!nolink [Service]) and Send File or Upload File (!nolink [Service]) to
+     Compress File Service and Send File or Upload File Service to
      Compress and Send or Compress and Upload, without the SRAs and
      the SPAs having to know about it.
 
-!item The protocol can be extended in many cases (e.g. with (!nolink [global])
+!item The protocol can be extended in many cases (e.g. with global
      contacts, see 5.) without interfering with any previous
      implementations and specifications.
 !end_itemize
@@ -309,7 +309,7 @@ its configuration files, without the user having to mess with
 anything.
 
 The user will have the possibility to switch single SPAs for certain
-services on and off, for example for the Status Display (!nolink [Service]) (see
+services on and off, for example for the Status Display Service (see
 sspServices.txt). Registration protocol still has to be specified.
 
 !end_node
@@ -318,13 +318,13 @@ sspServices.txt). Registration protocol still has to be specified.
 
 !begin_node SSP messages
 
-(!nolink [Messages]) are currently undefined. Free (!nolink [AES]) message numbers have to be
+Messages are currently undefined. Free (!nolink [AES]) message numbers have to be
 found and the SSP messages defined.
 
 
 !begin_enumerate
 
-!item (!nolink [Service Requesting Application Service]) Request
+!item Service Requesting Application Service Request
 !label SSP_SRASR
 
 !begin_verbatim
@@ -367,7 +367,7 @@ Fclose - send SRASR message to SSP-Server
 
 
 
-!item Server (!nolink [Service Initialization]) Request
+!item Server Service Initialization Request
 
 !label SSP_SSIR
 !begin_verbatim
@@ -393,7 +393,7 @@ respond with SSP_SPASI.
 
 
 
-!item (!nolink [Service Providing Application Service Initialization])
+!item Service Providing Application Service Initialization
 !label SSP_SPASI
 !begin_verbatim
 #define SSP_SPASI 0x1271
@@ -417,7 +417,7 @@ The Server holds the status of each session and can hence
 
 
 
-!item Server (!nolink [Service]) Use Request
+!item Server Service Use Request
 !label SSP_SSUR
 !begin_verbatim
 #define SSP_SSUR 0x1272
@@ -467,7 +467,7 @@ For SSP_UPLOADFILE (!I)sspPar1(!i) would be the ID of a shared memory
 
 
 
-!item (!nolink [Service Providing Application Service]) Acknowledge
+!item Service Providing Application Service Acknowledge
 !label SSP_SPASA
 !begin_verbatim
 #define SSP_SPASA 0x1273
@@ -484,7 +484,7 @@ session. Finally, the Server will send SSP_SSA to the SRA, after receiving SSP_S
 
 
 
-!item Server (!nolink [Service]) Acknowledge
+!item Server Service Acknowledge
 !label SSP_SSA
 !begin_verbatim
 #define SSP_SSA 0x1274
@@ -498,7 +498,7 @@ AES message-buffer:
 
 This indicates that the service is performing or has been performed, and the
 SRA can close and delete the (!link [shared memory][Shared memory])
-file u:/shm/[appl_id]_data[(!nolink [dataID])].ssp (e.g. 25_data0.ssp) using
+file u:/shm/[appl_id]_data[dataID].ssp (e.g. 25_data0.ssp) using
 Fdelete.
 
 !end_enumerate
@@ -512,10 +512,10 @@ Fdelete.
 
 The services are not directly requested by the SRA, but determined by
 the Server, from the data identification provided by the SRA in
-messagebuf[4] when sending (!nolink [SSP_SRASR]).
+messagebuf[4] when sending SSP_SRASR.
 !begin_itemize
 !label SSP_SENDFILE
-!item SSP_SENDFILE - Send File (!nolink [Service])
+!item SSP_SENDFILE - Send File Service
 
 (!U)Interactive IRS(!u)
 
@@ -545,7 +545,7 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
      deleted by the SRA.
 
      (!B)Notes:(!b) (!nl)
-     Synchronization of the (!nolink [global]) contacts and the local contacts of
+     Synchronization of the global contacts and the local contacts of
      the SPA can be done at this point. (!nl)
      Folders: if a directory name instead of a filename is passed,
      the SPA should try to send the complete file folder, including
@@ -553,14 +553,14 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
 
 
 !label SSP_STATUSDISPLAY
-!item SSP_STATUSDISPLAY - Status Display (!nolink [Service])
+!item SSP_STATUSDISPLAY - Status Display Service
 
      (!U)Invisible IRS(!u)
 
      Used to make any application (preferably those with permanent
      screen displays, for example TaskBar or MultiStrip or any
      Desktop) display status icons of other applications.
-     Also see the Context Popup (!nolink [Service]), which applications providing
+     Also see the Context Popup Service, which applications providing
      this service should implement to be able to request a popup menu
      in context to the current status from the SDS requesting app.
 
@@ -576,7 +576,7 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
      id of the SRA in msgbuf[6] for distinguishing different SRAs on
      the SPAs side (e.g. to maintain consistent status icon positions
      in the display). (!nl)
-     (!nolink [SSP_SSIR]) will be sent to all registered SPAs providing this
+     SSP_SSIR will be sent to all registered SPAs providing this
      service, that are switched on for SDS by the user. (!B)If (!I)requestID(!i)
      (messagebuf[1]) is SSP_ENDSDS, the SPA has to remove the icon
      referring to the status of the application with the (!I)appl_id(!i) sent.(!b)
@@ -598,16 +598,16 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
      (!B)Notes:(!b) (!nl)
      Upon registration of the SPAs with the Server, the Server will
      check if any not formerly registered apps providing the Status
-     Display (!nolink [Service]) have registered. If so, a list of these SPAs will
+     Display Service have registered. If so, a list of these SPAs will
      be presented to the user, with the possibility to turn the status
      display for single applications on and off. This makes it
      possible for the user to choose where the status icons are to be
      displayed. SPAs that are switched off for status display will
-     not receive (!nolink [SSP_SSIR]) messages from the Server.
+     not receive SSP_SSIR messages from the Server.
 
 
 !label SSP_DISPLAYMESSAGE
-!item SSP_DISPLAYMESSAGE - Display (!nolink [Message Service])
+!item SSP_DISPLAYMESSAGE - Display Message Service
 
      (!U)Invisible IRS(!u)
 
@@ -641,7 +641,7 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
 
 
 !label SSP_SENDMESSAGE
-!item SSP_SENDMESSAGE - Send (!nolink [Message Service])
+!item SSP_SENDMESSAGE - Send Message Service
 
      (!U)Interactive IRS(!u)
 
@@ -674,14 +674,14 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
      The Server will send SSP_SSA to the SRA.
 
      (!B)Notes:(!b) (!nl)
-     Synchronization of (!nolink [global]) and local contacts can be done at this
+     Synchronization of global and local contacts can be done at this
      point. The Server might be able to determine if the recipients
      are email addresses (maybe by the SPAs registration information)
      and provide a possibility to type in a new recipient for the
      user.
 
 !label SSP_UPLOADFILE
-!item SSP_UPLOADFILE - Upload File (!nolink [Service])
+!item SSP_UPLOADFILE - Upload File Service
 
      (!U)Interactive IRS(!u)
 
@@ -717,10 +717,10 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
 
      (!B)Notes:(!b) (!nl)
      The ftp servers, directories and user/pass combinations will be
-     held in (!nolink [global]) contacts as well, at some point. The SPA will
-     still send the local favorites, and the (!nolink [global]) contacts can be
+     held in global contacts as well, at some point. The SPA will
+     still send the local favorites, and the global contacts can be
      synchronized with the local contacts by the Server at this point.
-     Newly entered contacts can be integrated into the (!nolink [global])
+     Newly entered contacts can be integrated into the global
      contacts.
 
      Folders: if a directory name instead of a filename is passed,
@@ -728,7 +728,7 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
      all subdirectories and all files inside.
 
 !label SSP_COMPRESSFILE
-!item SSP_COMPRESSFILE - Compress File (!nolink [Service])
+!item SSP_COMPRESSFILE - Compress File Service
 (!U)Interactive DRS(!u)
 
      Used to make an archiver application compress a file
@@ -774,16 +774,16 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
 
 
 !label SSP_CONTEXT
-!item SSP_CONTEXT - Context (!nolink [Popup]) Service
+!item SSP_CONTEXT - Context Popup Service
 (!U)Interactive IRS(!u)
 
      Used to make an app display a context menu in context of the
-     current status displayed with the Status Display (!nolink [Service]) at
+     current status displayed with the Status Display Service at
      a certain position on screen, and react on the user's choice
      from the popup.
 
      (!B)This service will be requested by the application that provides
-     the Status Display (!nolink [Service])! SPA will in this case also be SRA
+     the Status Display Service SPA will in this case also be SRA
      and SRA also SPA.(!b)
 
      Upon sending of the SSP_SRASR message from the SRA (the SDS
@@ -794,7 +794,7 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
      returned from evnt_button or evnt_multi.
      messagebuf[9] has to contain the application ID of the
      application that the status icon refers to. The (!I)appl_id(!i) for
-     every icon is sent with the Status Display (!nolink [Service]). dataID has
+     every icon is sent with the Status Display Service. dataID has
      to be SSP_CONTEXTREQUEST.
 
      The Server will request SSP_POPUP from the SPA with SSP_SSIR.
@@ -810,12 +810,12 @@ messagebuf[4] when sending (!nolink [SSP_SRASR]).
      mouse button vector, stating which button(s) have been pressed,
      as usually returned by the (!nolink [AES]) evnt_xx functions. The SPA will
      then display its context popup, preferably in context to the
-     current status displayed with the Status Display (!nolink [Service]).
+     current status displayed with the Status Display Service.
 
      After the user has chosen a popup entry, the SPA will send
      SSP_SPASA.
 
-     The SRA (the Status Display (!nolink [Service]) providing application) will
+     The SRA (the Status Display Service providing application) will
      receive SSP_SSA.
 
      (!B)Notes:(!b) (!nl)
@@ -840,24 +840,24 @@ possible, to provide responsivity and reasonable user feedback.
      frequently used accessible quickly and easily.
 
 !label SSP_DISPLAYINFO
-!item SSP_DISPLAYINFO - Display Information (!nolink [Service])
+!item SSP_DISPLAYINFO - Display Information Service
 (!U)Interactive IRS(!u)
 
      Used to make an app send information (will mostly be used in
      context of the current status displayed with the Status Display
-     (!nolink [Service])) in the form of ASCII text. Can be used, for example, if
+     Service) in the form of ASCII text. Can be used, for example, if
      a BubbleGEM event on a Status Icon occurs in TaskBar, to make
      the application requesting the status display send extended
      information about the current status for TaskBar to display.
 
      This service will probably most commonly be requested by the
-     application that provides the Status Display (!nolink [Service])! SPA will
+     application that provides the Status Display Service SPA will
      in this case also be SRA and SRA also SPA.
 
      Another possibility would be PS-Control-like applications, that
      show system information about running processes (CPU and memory
      usage, etc.). These could then also display information about the
-     application's current status. (!nolink [N.AES]) could use this service to
+     application's current status. N.AES could use this service to
      display the current status of the applications when switching
      apps with [Alternate]+[Tab].
 
@@ -883,7 +883,7 @@ possible, to provide responsivity and reasonable user feedback.
      The SPA will send SSP_SPASA (!B)after copying the string to shm and
      freeing temporary memory.(!b)
 
-     The SRA (e.g. the Status Display (!nolink [Service]) providing application)
+     The SRA (e.g. the Status Display Service providing application)
      will receive SSP_SSA. This indicates that the information is
      now in the shared memory file provided at SSP_SRASR and can be
      displayed, and the shm-file deleted.
@@ -914,14 +914,14 @@ possible, to provide responsivity and reasonable user feedback.
 
 !begin_node SSP Server registration
 
-(!nolink [Messages]) are currently undefined. Free (!nolink [AES]) message numbers have to be
+Messages are currently undefined. Free (!nolink [AES]) message numbers have to be
 found and the SSP messages defined.
 
 All SPAs have to register with the Server at installation and at
 every startup of the application. Here's how it works:
 
 !begin_enumerate
-!item (!nolink [Service]) Providing Application Server registration
+!item Service Providing Application Server registration
 
  #define SSP_SPASREG
 
@@ -990,7 +990,7 @@ services are provided. Response to this message is SSP_SREG.
 
 
 
-!item SSP (!nolink [Service]) Providing Application Registration Finish
+!item SSP Service Providing Application Registration Finish
 
  #define SSP_SPARF
 
@@ -1054,7 +1054,7 @@ Upon sending this message, the shm-block provided with SSP_SREG
      apply to the SRA as well. For the current services it is
      absolutely necessary that the SPA does not write to the shared
      memory blocks. Exceptions from this rule so far: Display
-     Information (!nolink [Service]).
+     Information Service.
 
 !end_itemize
 
@@ -1068,14 +1068,14 @@ memory for data transfer. Reasons that speak for shared memory are
 the following:
 
 !begin_itemize
-!item   Shared memory is generally considered 'cleaner' than (!nolink [global])
+!item   Shared memory is generally considered 'cleaner' than global
      memory blocks, and it's more or less the standard way to transfer
      data in memory between applications in Un*x operating systems.
 
-!item Using (!nolink [global]) memory blocks would mean that the SRA would have to
-     either hold all possibly transferrable data in (!nolink [global]) blocks (not
+!item Using global memory blocks would mean that the SRA would have to
+     either hold all possibly transferrable data in global blocks (not
      really an option), or, upon requesting a service, would have to
-     allocate a new (!nolink [global]) block of the size of the data, copy the
+     allocate a new global block of the size of the data, copy the
      data to transfer there and free the memory block again after the
      service was performed. Handling shared memory is easier, since it
      only consists of an Fcreate and an Fcntl call.
@@ -1097,7 +1097,7 @@ the following:
 
 There will be no SRA-side timeouts. Timing out will be handled
 completely on the Server side, because a) the SRA doesn't know about
-Immediate or Delayed Response (!nolink [Services]), and b) depending on the SPA
+Immediate or Delayed Response Services, and b) depending on the SPA
 that might have to be started first, startup time may screw up SRA-
 side timeouts. Besides that, it takes even more work off the SRA's
 back ;)
@@ -1118,7 +1118,7 @@ determinations. For example, If the SPA knows an error occured, it can
 send an error-message instead of SSP_SPASA. Still, in case of a crash
 of the SPA, a timeout has to be implemented.
 
-Compress File (!nolink [Service]) timeouts can be done with consideration of the
+Compress File Service timeouts can be done with consideration of the
 time between size changes of the archive file, opened and closed files
 or memory usage of the SPA. If none of the above changes, at some
 point it's safe to say that some error occured during performing the
@@ -1126,7 +1126,7 @@ service (probably a crash of the SPA). In this case the Server could
 try to terminate what's left of the SPA, close (!link [shared memory][Shared memory]) files,
 clean up and close the communication session and start the whole thing
 over (Server-side retry). If that doesn't work, the Server will send
-@{"SSP_SSA" ignore} to the SRA to acknowledge and make sure the SRA frees
+SSP_SSA to the SRA to acknowledge and make sure the SRA frees
 temporary memory and closes shared memory files, and then display an
 error-message.
 
@@ -1168,7 +1168,7 @@ Provided Services for Server registration
 #define SSP_PDISPLAYINFO     0x80
 !end_verbatim
 
-(!nolink [Services for Service Requesting Application Service Request])
+Services for Service Requesting Application Service Request
 
 Same as when registering to the Server.
 
@@ -1185,29 +1185,29 @@ Same as when registering to the Server.
 
 
 !label dataID
-(!U)Data identification for (!nolink [Service]) Requesting Application (!nolink [Service]) Request(!u)
+(!U)Data identification for Service Requesting Application Service Request(!u)
 
 messagebuf[4], identifies the type of data for the Server to determine
 possible services.
 
  #define SSP_TEXT   0x01 (!nl)
 The (!link [shared memory][Shared memory]) block contains NULL-terminated ASCII text. Possible services will be:
-(!nolink [SSP_DISPLAYMESSAGE]),
-(!nolink [SSP_SENDMESSAGE]) (sends or displays the text directly) (!nl)
-(!nolink [SSP_SENDFILE]),
-(!nolink [SSP_UPLOADFILE]),
-(!nolink [SSP_COMPRESSFILE]) and combinations (sends, uploads or compresses Text as file)
+SSP_DISPLAYMESSAGE,
+SSP_SENDMESSAGE (sends or displays the text directly) (!nl)
+SSP_SENDFILE,
+SSP_UPLOADFILE,
+SSP_COMPRESSFILE and combinations (sends, uploads or compresses Text as file)
 
  #define SSP_FILENAME  0x02 (!nl)
 The shared memory block contains Null-terminated file path and -name. Possible
 services will be:
-(!nolink [SSP_SENDFILE]),
-(!nolink [SSP_UPLOADFILE]),
-(!nolink [SSP_COMPRESSFILE]) and combinations (sends, uploads or compresses file)
+SSP_SENDFILE,
+SSP_UPLOADFILE,
+SSP_COMPRESSFILE and combinations (sends, uploads or compresses file)
 
  #define SSP_STATUSICON  0x04 (!nl)
 The shared memory block contains Icon data. Possible Service:
-(!nolink [SSP_STATUSDISPLAY]) (!nl)
+SSP_STATUSDISPLAY (!nl)
 This service will be started and performed without user interaction. The server will,
 when receiving SSP_SRASR with SSP_STATUSICON as dataID, send a request for
 SSP_STATUSDISPLAY to the SPA.
@@ -1220,7 +1220,7 @@ SSP_DISPLAYINFO
 
  #define SSP_CONTEXTREQUEST  0x10 (!nl)
 No shared memory block has to be created. This dataID indicates use of the Context
-(!nolink [Popup Service]).
+Popup Service.
 Possible Service: (!nl)
 SSP_CONTEXT
 
@@ -1231,7 +1231,7 @@ service(!b). It provides a certain type of data to the Server (and thus to
 the SPA), and the Server determines which services can be used with
 this type of data. In case of SSP_CONTEXT, SSP_INFOBUF and
 SSP_STATUSICON there is only one possible service. The Status Display,
-Display Information and Context Popup (!nolink [Services]) are usually used in
+Display Information and Context Popup Services are usually used in
 conjunction.
 
 SRA-side definition of a data-type has the advantage that new
@@ -1243,7 +1243,7 @@ like this:
 
 
 !begin_table [|l|l|] !hline
-System (!nolink [Services]) -> !!     Send File
+System Services -> !!     Send File
 ~ !!      Upload File
 ~ !!      Compress File
 ~ !!      Compress & Send
@@ -1254,7 +1254,7 @@ System (!nolink [Services]) -> !!     Send File
 While for SSP_TEXT it could be like this:
 
 !begin_table [|l|l|] !hline
-    System (!nolink [Services]) -> !!      Send as message
+    System Services -> !!      Send as message
 ~ !!        Send as File
 ~ !!        Upload as File
 ~ !!        Compress as File
@@ -1318,7 +1318,7 @@ memory filename ((!I)shmID(!i) passed in SSP_SRASR).
 Multiple sessions from your application at a time can occur for
 example like this:
 !begin_itemize
-!item AtarIRC as SRA of Status Display (!nolink [Service]) sends SSP_SRASR with dataID
+!item AtarIRC as SRA of Status Display Service sends SSP_SRASR with dataID
 SSP_STATUSICON to change the status display, due to starting a dcc
 download from a user
 
@@ -1332,7 +1332,7 @@ if a session is active or not. Each bit represents a possible session.
 Before starting a session (before sending SSP_SRASR), check the bits
 from 0 to 31. If a bit is not set, another session can be opened. Set
 the bit and use the index of the bit as the session ID ((!I)shmID(!i)). This
-code uses the (!nolink [global]) 32-bit integer sessionVector as the indicator for
+code uses the global 32-bit integer sessionVector as the indicator for
 active sessions, and returns the next inactive session number, or -1,
 if all possible 32 sessions are active:
 
@@ -1378,7 +1378,7 @@ for later use. This is done basically the same way it is in OLGA:
       !item Start Server with shel_write
       !item Read environment variable SSP_SERVERNAME to retrieve the
             Server application name
-      !item Use (!nolink [appl_find]) to determine the Server's (!I)appl_id(!i)
+      !item Use appl_find to determine the Server's (!I)appl_id(!i)
       !item If the Server application is not in the specified path or
             if starting fails:
         !begin_itemize
@@ -1406,12 +1406,12 @@ for later use. This is done basically the same way it is in OLGA:
 To use a service, the SSP_SRASR (!nolink [AES]) message has to be sent to the
 Server. Before sending the message, determine the data-type used. For
 example, if a block has been selected in an editor and the user wants
-to use SSP by right clicking and choosing System (!nolink [Services]) from the
+to use SSP by right clicking and choosing System Services from the
 context menu, or from the editor's menu bar, the data-type (referred
 to as dataID) is SSP_TEXT. If for example an image file or MP3 is to
 be handled via SSP, the data-type should be SSP_FILENAME.
 
-For the Status Display (!nolink [Service]), the data-type has to be
+For the Status Display Service, the data-type has to be
 SSP_STATUSICON. This service should be initialized automatically,
 without user interaction, after the Server has been started, at
 program startup. See also 'Data identification' for SSP_SRASR for
@@ -1434,7 +1434,7 @@ The shared memory ID is vital to the Server, because it is used to
 distinguish between different service requests and SRA communication
 sessions that are 'alive' at the same time. A session is 'alive'
 between the sending of SSP_SRASR and receiving SSP_SSA. For example,
-the user could make your application request Send File (!nolink [Service]), while
+the user could make your application request Send File Service, while
 you haven't gotten the SSP_SSA response for the SSP_STATUSICON
 request. This would make you open a second session, and a second
 shared memory file, while the session for the status display is still
@@ -1466,7 +1466,7 @@ is a pointer to the memory block to share. buildFilename takes a
 determined session ID as parameter, builds a filename from it and
 returns a pointer to the static string containing the filename.
 buildFileName assumes (!I)appl_id(!i) being the SRA's (your) application ID
-available as a (!nolink [global]) variable!
+available as a global variable!
 
 
 !begin_verbatim
@@ -1503,9 +1503,9 @@ passes the (!I)shmID(!i) that it received from the SRA back to it, in the
 SSP_SSA acknowledge message, so the filename can be built again to
 delete the file.
 
-(!U)2.2.2 Sending a (!nolink [Service]) Request(!u)
+(!U)2.2.2 Sending a Service Request(!u)
 
-Send an (!nolink [SSP_SRASR]) message to the Server, filling the (!nolink [AES]) message-
+Send an SSP_SRASR message to the Server, filling the (!nolink [AES]) message-
 buffer with the following values:
 
 !begin_verbatim
@@ -1558,7 +1558,7 @@ free all temporary memory you have possibly allocated for the service
 request, and you're done. The following code uses the above function
 buildFilename and the (!I)sessionID(!i) from messagebuf[1] as a parameter to
 build a filename, delete the shm-file, and clear the bit of the
-session in the (!nolink [global]) sessionVector variable:
+session in the global sessionVector variable:
 
 
 !begin_verbatim
@@ -1579,10 +1579,10 @@ internal buffers for filenames, text or other data, directly). This
 could be done by adding a parameter (!I)tmpFlag(!i) to the openSession
 function that indicates if (!I)memPtr(!i) is a temporary buffer.
 openSession could then automatically insert (!I)memPtr(!i) or NULL at the
-appropriate position in a (!nolink [global]) array, one entry for every session,
+appropriate position in a global array, one entry for every session,
 with sessionID as the index. closeSession could then get the pointer
 from the array at the index of its parameter (!I)sessionID(!i) and perform
-@{"Mfree" ignore} on the pointer, if it's not NULL. This would automate and
+Mfree on the pointer, if it's not NULL. This would automate and
 connect the processes of opening and closing sessions internally,
 creating and deleting (!link [shared memory][Shared memory]) files, and freeing possible
 temporary buffers.
@@ -1590,19 +1590,19 @@ temporary buffers.
 
 (!U)4. The different dataIDs and their impact on sessions(!u)
 
-(!U)4.1 SSP_STATUSICON request and the Status Display (!nolink [Service])(!u)
+(!U)4.1 SSP_STATUSICON request and the Status Display Service(!u)
 
 The dataIDs have an influence on how a session and service is handled
 internally. For SSP_TEXT and SSP_FILENAME, you don't have to worry
 about it, just go by the above scheme. For SSP_STATUSICON however,
 there is a twist. The status icon will be displayed by all
-applications that are switched on for Status Display (!nolink [Service]). The
+applications that are switched on for Status Display Service. The
 service is invisible, meaning it won't be triggered by a user action
 rather than automatically, on program startup and anytime the status
 of your program changes. When that happens, and you want to display a
 different status icon, you have to send another request with
 SSP_STATUSICON as dataID. All 'on' applications for Status Display
-(!nolink [Service]) will then update the icon they display for your application's
+Service will then update the icon they display for your application's
 status.
 
 When you exit your application and have sent a service request with
@@ -1622,12 +1622,12 @@ progress bar phase.
 
 (!U)4.2 Requesting SSP_STATUSICON will make your SRA an SPA(!u)
 
-Applications that provide Status Display (!nolink [Service]) will usually be
+Applications that provide Status Display Service will usually be
 able to request the SSP_DISPLAYINFO and SSP_CONTEXTPOPUP services.
 This means that if you request service with SSP_STATUSICON as dataID,
-you will probably receive a request for (!nolink [SSP_DISPLAYINFO]) or
+you will probably receive a request for SSP_DISPLAYINFO or
 SSP_CONTEXTPOPUP at some point! Look at How to implement an SPA on
-how to provide the Display Information and Context (!nolink [Popup]) services.
+how to provide the Display Information and Context Popup services.
 
 (!U)4.3 The icon data(!u)
 
@@ -1678,7 +1678,7 @@ size. And, which application really has 20 different statii?
 
 (!U)5. Guidelines for implementing SPAs(!u)
 !begin_itemize
-    !item Make your icons for the Status Display (!nolink [Service]) distinguishable (so people can
+    !item Make your icons for the Status Display Service distinguishable (so people can
           see it is this specific application's status icon) and recognizeable (so the
           user doesn't have to wonder 'what the heck is that supposed to be?').
 
@@ -1724,14 +1724,14 @@ Response services.
 
 
 
-(!B)1. Receiving (!nolink [Service Initialization]) Request and determining the
+(!B)1. Receiving Service Initialization Request and determining the
 information type(!b)
 
 The SPA (your application) will receive the SSP_SSIR message to
 indicate use of a service your application provides. The Server
 knows the services provided by your application from the Server
 registration, so you will only receive requests for services you
-actually provide. The message-buffer with (!nolink [SSP_SSIR]):
+actually provide. The message-buffer with SSP_SSIR:
 !begin_verbatim
   [0] = SSP_SSIR
   [1] = serviceID
@@ -1745,7 +1745,7 @@ which information to provide.
 
 (!I)requestID(!i) (messagebuf[2]) is an identification that tells you which
 information to provide to the Server. For example, if Send File
-(!nolink [Service]) has been requested by the user, you will receive
+Service has been requested by the user, you will receive
 SSP_RECIPIENTS as (!I)requestID.(!i) Build a list of possible recipients
 (depending on the type of your application) separated by CRLF,
 terminated by NULL. If your application is an IRC Client for example,
@@ -1774,11 +1774,11 @@ For example, if your application has (!I)appl_id(!i) 25 and (!I)sessionID(!i) is
 u:/shm/25_init0.ssp
 
 After you have built the name for the shared memory file, use
-@{"Fcreate" ignore} to create the file. Read/Write access rights have to be set
+Fcreate to create the file. Read/Write access rights have to be set
 correctly, depending on the request type! (!nl)
 Then, bind the memory block that contains the requested information
 (list of recipients, etc., depending on (!I)requestID(!i) and (!I)serviceID(!i)) to
-the file using (!nolink [Fcntl]). The following code will build the filename and
+the file using Fcntl. The following code will build the filename and
 open an initialization data shared memory file when calling
 createShmFile:
 
@@ -1811,7 +1811,7 @@ createShmFile:
 !end_verbatim
 
 
-(!U)2.2.2 Sending (!nolink [Service Initialization]) (!u)
+(!U)2.2.2 Sending Service Initialization (!u)
 
 Send an SSP_SPASI message to the Server, filling the (!nolink [AES]) message-
 buffer with the following values:
@@ -1824,7 +1824,7 @@ buffer with the following values:
 The session ID sent to you with SSP_SSIR.
 
 
-(!B)3. Receiving (!nolink [Service]) Use Request(!b)
+(!B)3. Receiving Service Use Request(!b)
 
 When your application receives SSP_SSUR, this means that a service
 should be performed now.
@@ -1834,11 +1834,11 @@ This makes it possible for you to keep initializing and performing
 services separate from one another. The (!I)serviceID(!i) will be the same
 throughout one session.
 
-messagebuf[2] will contain the same (!I)sessionID(!i) as in (!nolink [SSP_SSIR]).
+messagebuf[2] will contain the same (!I)sessionID(!i) as in SSP_SSIR.
 
 messagebuf[3]/[4] will build a LONG that is the number of the
 information part of all the parts you provided in SSP_SPASI. For
-example, if you have sent 10 recipients for a Send File (!nolink [Service])
+example, if you have sent 10 recipients for a Send File Service
 request, and this LONG is 0, the first recipient in the list is to
 receive the file.
 
@@ -1903,9 +1903,9 @@ you don't need to read from or write to it any more (before acknowledging the
 Server) with Fclose! Delete the initialization shm-file when receiving SSP_SSUR
 and free temporary memory, if any!
 
-(!B)4. Performing the (!nolink [Service]) and acknowledging(!b)
+(!B)4. Performing the Service and acknowledging(!b)
 
-(!U)4.1 Performing the (!nolink [Service])(!u)
+(!U)4.1 Performing the Service(!u)
 
 Depending on the parameters sent in SSP_SSUR you can determine what to
 do. Ultimately the way your application performs certain services is
@@ -1916,19 +1916,19 @@ up to you, and also depends on the type of your application. See
 
 Acknowledging a service is done by sending SSP_SPASA to the Server.
 When you do this depends on your application and on the type of
-service (IRS or DRS). With Immediate Response (!nolink [Services]), you should
+service (IRS or DRS). With Immediate Response Services, you should
 start performing the service (e.g. open a connection to a user and
 start sending a file) and acknowledge before the service is actually
 finished.
 
-With Delayed Response (!nolink [Services]) (e.g. the Compress File (!nolink [Service]))
+With Delayed Response Services (e.g. the Compress File Service)
 acknowledging should not be done before the service is completely
 performed (e.g. the files are compressed).
 
 
 (!B)5. Guidelines for performing services(!b)
 
-(!U)5.1 Send File (!nolink [Service])(!u)
+(!U)5.1 Send File Service(!u)
 
 (!B)For online Clients like IRC and ICQ:(!b) (!nl)
 When receiving SSP_SSIR with SSP_RECIPIENTS, only provide online
@@ -1942,7 +1942,7 @@ Encode the file into an attachment, and open an email editor window
 for typing in text. Make sure the received attachment and the typed
 email go out together.
 
-(!U)5.2 Send (!nolink [Message Service])(!u)
+(!U)5.2 Send Message Service(!u)
 
 (!B)For online Clients like IRC and ICQ:(!b) (!nl)
 For SSP_RECIPIENTS, provide a list only of open chats or chat
@@ -1957,7 +1957,7 @@ user answers this question with 'Yes'. Acknowledge as soon as the user
 has answered the question. If this security request is turned off,
 send immediately.
 
-(!U)5.2 Display (!nolink [Message Service])(!u)
+(!U)5.2 Display Message Service(!u)
 
 (!B)For online Clients like IRC and ICQ:(!b) (!nl)
 You will not receive SSP_RECIPIENTS. This service can be triggered
@@ -1971,7 +1971,7 @@ You will not receive SSP_RECIPIENTS. Insert the text message into the
 currently top open email editor window. If none is open, open one with
 no recipient and insert the message there.
 
-(!U)5.3 Upload File (!nolink [Service])(!u)
+(!U)5.3 Upload File Service(!u)
 
 (!B)For FTP Clients:(!b) (!nl)
 Provide a list of recipients in shm as described here. Retrieve the
@@ -1979,25 +1979,25 @@ Server and directory name from the shm-block provided with SSP_SSUR,
 and upload the file. Acknowledge after opening the connection and
 starting to upload.
 
-(!U)5.4 Status Display (!nolink [Service])(!u)
+(!U)5.4 Status Display Service(!u)
 
 Retrieve the icon data, copy it into your own buffers. Display new
 icon. Acknowledge.
 
-(!U)5.5 Display Information (!nolink [Service])(!u)
+(!U)5.5 Display Information Service(!u)
 
 Copy information text, NULL terminated, to the shm-block provided. Acknowledge.
 
-5.6 Context (!nolink [Popup Service])
+5.6 Context Popup Service
 
 Retrieve coordinates for the context popup from the message-buffer.
 Open context popup in context to the current status icon from the
-Status Display (!nolink [Service]). Make frequently used and status dependend
+Status Display Service. Make frequently used and status dependend
 options available in the context popup. Make all information available
 in the context popup also available directly by your application! The
 context popup is never to supersede generally available options!
 
-(!U)5.7 Compress File (!nolink [Service])(!u)
+(!U)5.7 Compress File Service(!u)
 
 Provide different archive types and compression levels after receiving
 SSP_FORMATS. Use the format number contained in (!I)sspPar1(!i) at SSP_SSUR.
@@ -2038,21 +2038,21 @@ finished.
 
 (!B)AtarICQ (!b)
 
-SRA: Status Display, Display (!nolink [Message]), Send (!nolink [Message]) (!nl)
-SPA: Context (!nolink [Popup]), Display Information, Send File, Display (!nolink [Message]),
-Send (!nolink [Message])
+SRA: Status Display, Display Message, Send Message (!nl)
+SPA: Context Popup, Display Information, Send File, Display Message,
+Send Message
 
 (!B)AtarIRC (!b)
 
-SRA: Status Display, Display (!nolink [Message]), Send (!nolink [Message]) (!nl)
-SPA: Context (!nolink [Popup]), Display Information, Send File, Display (!nolink [Message]),
-Send (!nolink [Message])
+SRA: Status Display, Display Message, Send Message (!nl)
+SPA: Context Popup, Display Information, Send File, Display Message,
+Send Message
 
 (!B)EditorLib (!b)
 
-SRA: Display (!nolink [Message]), Send (!nolink [Message]), Send (text as) File, Upload (text
+SRA: Display Message, Send Message, Send (text as) File, Upload (text
 as) File, Compress File (!nl)
-SPA: Display (!nolink [Message])
+SPA: Display Message
 
 (!B)GuiTar (!b)
 
@@ -2065,26 +2065,26 @@ SRA: Send File, Upload File, Compress File
 
 (!B)TaskBar (!b)
 
-SRA: Context (!nolink [Popup]), Display Information (!nl)
+SRA: Context Popup, Display Information (!nl)
 SPA: Status Display
 
 (!B)TextView (!b)
 
-SRA: Display (!nolink [Message]), Send (!nolink [Message]), Send (text as) File, Upload (text
+SRA: Display Message, Send Message, Send (text as) File, Upload (text
 as) File, Compress File, Send File (!nl)
-SPA: Display (!nolink [Message])
+SPA: Display Message
 
 (!B)ACSPro (!b)
 
-SRA: Display (!nolink [Message]), Send (!nolink [Message]), Send (text as) File, Upload (text
+SRA: Display Message, Send Message, Send (text as) File, Upload (text
 as) File, (!nl)
-SPA: Display (!nolink [Message]) (!nl)
+SPA: Display Message (!nl)
 All applications built with ACSPro could provide SSP support generated
 by ACSPro.
 
 (!B)FalcAmp (!b)
 
-SRA: Display (!nolink [Message]), Send File, Upload File, Compress File
+SRA: Display Message, Send File, Upload File, Compress File
 
 !end_node
 
@@ -2109,7 +2109,7 @@ SRA has requested a service. All SPAs have to register with the SSP-Server.
 !item [Service]
 is a certain part of an applications functionality or capability that can be
 provided to, and used by, other applications using SSP. Generalized types of
-services are hardwired into the SSP-Server. See SSP services.
+services are hardwired into the SSP-Server. See (!link [SSP services] [Services]).
 
 !label IRS
 !item [IRS]
@@ -2136,21 +2136,21 @@ See (!link [Send File Service][SSP_SENDFILE]).
 !item [Server Registration]
 All SPAs have to register with the SSP-Server before they can provide and
 perform any services. Registration should be done once on program installation
-and every time the SPA starts up. See SSP Server registration.
+and every time the SPA starts up. See (!link [SSP Server registration] [SSP Server registration]).
 
 !label SSP-Server
 !item [Server]
 or (!B)SSP-Server(!b)  Application running in the background that receives and
 sends messages from and to SPAs and SRAs. All communication between SPAs and
 SRAs has the SSP-Server as mediator. (!nl)
-See What is the SSP-Server?
+See (!link [What is the SSP-Server?] [What is the SSP-Server?])
 
 !label Message
 !item [Message]
 in these documents refers to an (!nolink [AES]) message received by evnt_mesag
 (or evnt_multi, respectively). The communication in SSP is based on
 (!nolink [AES]) messages. (!nl)
-See SSP messages.
+See (!link [SSP messages] [SSP messages]).
 
 !label Server debug mode
 !item [Server debug mode]

--- a/protokol/xfsl.u
+++ b/protokol/xfsl.u
@@ -1,6 +1,7 @@
 !iflang [english]
 
 !begin_node xFSL interface
+!html_name proto_xfsl
 
 GDOS, which for years suffered a shadowy existence on the Atari
 platform, has enjoyed rising popularity since the introduction of
@@ -124,7 +125,7 @@ The version number of the installed font-selector as BCD
            number (e.g. hexadecimal 0x100 for Version 1.00). The same
            notes apply here as for the (!I)product(!i) field above.
 
-!item [(!nolink [xfsl_input])]
+!item [xfsl_input]
 This is the entry point for a simplified call of the
            font-selector. The font-selector then appears always as a
            modal dialog and most of the additional features of the
@@ -142,7 +143,7 @@ These three functions together form
   !item Remove font-selector from the screen (xfsl_exit)
  !end_enumerate
 
-!item [(!nolink[xfsl_info])]
+!item [xfsl_info]
 With this call one can inquire about some of the features
            of the installed font-selector, e.g. Drag&Drop support.
 !end_ilist
@@ -466,7 +467,7 @@ by xfsl_init.
 
 xfsl_exit must be called always when the use of the font-selector is
 to be ended, be it that a font was chosen or 'Cancel' was selected,
-or that xfsl_event reported an error. If already the (!nolink [xfsl_init]) call
+or that xfsl_event reported an error. If already the xfsl_init call
 failed, then xfsl_exit may (!I)not(!i) be called (logical, since one has no
 valid handle).
 
@@ -546,19 +547,19 @@ For this one should note that the font-selector also opens its own
 (!nolink [VDI]) workstation and uses this internally and for the selection of the
 fonts. Amongst other things it will also call vst_load_fonts for this
 workstation (provided a GDOS is (!nolink [installed])). This can lead to some
-unexpected results if no (!nolink [vst_load_fonts]) has been called yet on the
+unexpected results if no vst_load_fonts has been called yet on the
 passed workstation and the user selects a font in the font-selector
-that only becomes available after a (!nolink [vst_load_fonts]) call!
+that only becomes available after a vst_load_fonts call!
 
 !smallskip
 
 Instead of a workstation handle however one can also simply pass a
 NULL. The font-selector will then ascertain the current font from the
-passed parameters (for a (!nolink [xfsl_input]) call) or from the xFSL_PAR
-structure (for a (!nolink [xfsl_init]) call).
+passed parameters (for a xfsl_input call) or from the xFSL_PAR
+structure (for a xfsl_init call).
 
 The selected font will then (logically) only be returned in the
-parameters or the (!nolink [xFSL_PAR]) structure and the caller then has to set
+parameters or the xFSL_PAR structure and the caller then has to set
 it him/herself.
 
 !end_node
@@ -615,7 +616,7 @@ xpar.par_size=sizeof(xFSL_PAR);
 
 !item [(!V)pfi_size(!v)]
 This field too may not be zero; here one has to enter
-             the size of the (!nolink [PFONTINFO]) structure, so in C:
+             the size of the PFONTINFO structure, so in C:
 !begin_quote
 !begin_verbatim
 xpar.pfi_size=sizeof(PFONTINFO);
@@ -726,7 +727,7 @@ understand can simply be set to zero at first. Exceptions are only:
 !begin_itemize
  !item (!I)par_size(!i), the size of the xFSL_PAR structure itself
  !item (!I)pfi_size(!i), the size of the PFONTINFO structure
- !item (!I)font(!i), the pointer to the (!nolink [PFONTINFO]) structure
+ !item (!I)font(!i), the pointer to the PFONTINFO structure
 !end_itemize
 
 !end_node
@@ -1277,7 +1278,7 @@ In addition, GEMDOS error messages (values smaller or equal to -32)
 can occur; in particular, xfsl_init can also return the value EINVFN
 (-32) if the font-selector does not support the extended call.
 
-With the (!nolink [xfsl_init]) call, positive return values correspond to the
+With the xfsl_init call, positive return values correspond to the
 font-selector's window handle (0 means that the font-selector was
 opened as a modal dialog).
 
@@ -1319,7 +1320,7 @@ typedef struct /* Special type for EventMulti */
 The elements of the structure correspond to those of the evnt_multi
 call. The order of the parameters too - apart from a few exceptions -
 is identical. The field (!I)ev_mwich(!i) contains the occurred events in the
-same coding as (!I)ev_mflags(!i) in (!nolink [evnt_multi]).
+same coding as (!I)ev_mflags(!i) in evnt_multi.
 
 !end_node
 
@@ -1393,14 +1394,14 @@ void call_xfsl (void)
 !end_verbatim
 !end_quote
 
-With the two memset calls all elements of the structures (!nolink [xFSL_PAR]) and
-(!nolink [PFONTINFO]) are set to zero. Subsequently some absolutely necessary
+With the two memset calls all elements of the structures xFSL_PAR and
+PFONTINFO are set to zero. Subsequently some absolutely necessary
 values are entered:
 
 !begin_itemize
  !item The size of the two structures xFSL_PAR and PFONTINFO
- !item The address of the (!nolink [PFONTINFO]) structure is entered in the
-    (!nolink [xFSL_PAR]) structure
+ !item The address of the PFONTINFO structure is entered in the
+    xFSL_PAR structure
  !item The font colour is set to black (one could also omit this, but
      normally one wants to write in black type on a white background)
 !end_itemize
@@ -1617,7 +1618,7 @@ a warning with compiler switch '-A' (ANSI-conform) set.
      to older revisions. This should not be a problem in practice, as
      the font-selector will quit calls according to the old scheme
      with an error. The old Revision 3 will disappear in time.
- !item New parameters in the (!nolink [PFONTINFO]) structure:
+ !item New parameters in the PFONTINFO structure:
        !begin_itemize
         !item Text background colour ((!I)backcol(!i))
         !item Text alignment ((!I)halign(!i) and (!I)valign(!i))
@@ -1625,7 +1626,7 @@ a warning with compiler switch '-A' (ANSI-conform) set.
         !item Specification of characters that the selected font (!B)has(!b) to
               contain ((!I)validtype(!i) and (!I)validchars(!i))
        !end_itemize
- !item The (!nolink [PFONTINFO]) structure is also filled for returns of (!nolink [xFS_STOP])
+ !item The PFONTINFO structure is also filled for returns of xFS_STOP
      with the values of the last font selected in the font-selector
  !item Coding of the font-flags changed (finer differentiation of the
      vector formats)
@@ -1703,13 +1704,13 @@ A short overview of the currently existig font-selectors:
 
 !raw [stg] @index "Calvino"
 !item [Calvino] by Dirk Haun (!nl)
-     Together with HuGo! the first font-selector with a (!nolink [xFSL interface]).
-     Calvino too still supports the simple (!nolink [UFSL interface]).
+     Together with HuGo! the first font-selector with a xFSL interface.
+     Calvino too still supports the simple UFSL interface.
 
 !item [FONT_SEL und FONT_PAL] by Christian Grunenberg (!nl)
      These two programs work on a Drag&Drop basis, so they support
-     neither the UFSL nor the (!nolink [xFSL interface]), but instead support the
-     (!nolink [Font protocol]). FONT_SEL is a font-selector, FONT_PAL a font
+     neither the UFSL nor the xFSL interface, but instead support the
+     Font protocol. FONT_SEL is a font-selector, FONT_PAL a font
      palette (with integrated font-selector).
 !end_description
 
@@ -1722,7 +1723,7 @@ The following programs support an external font-selector (position at
 16.08.1998, all specifications without guarantee):
 
 !begin_table [l|l|l|c|c]
- Program       !! Category            !!  Author                   !! (!nolink [UFSL]) !! xFSL
+ Program       !! Category            !!  Author                   !! UFSL !! xFSL
 !hline
  800XL-Deejay  !! Drive emulator      !! Kolja Koischwitz          !! +   !!
  APP_List      !! System utility      !! Ralf Zimmermann           !! +   !!
@@ -1915,7 +1916,7 @@ the font-selector almost exclusively as a modal dialog. Thus the
 recommendation is to build in minimal UFSL support (as a modal dialog
 only) and instead implement the xFSL interface as widely as possible,
 since one can now expect that just those - now finally standardized -
-extensions will be used by programs rather than the  (!nolink [UFSL interface]).
+extensions will be used by programs rather than the  UFSL interface.
 
 A font-selector should offer the following additional features if
 possible:
@@ -2015,6 +2016,8 @@ D-71717 Beilstein
 !else
 
 !begin_node xFSL-Schnittstelle
+!html_name proto_xfsl
+
 SpÑtestens seit der EinfÅhrung von Vektorfonts erfreut sich das GDOS, das
 jahrelang auf dem Atari ein Schattendasein fÅhrte, steigender
 Be!-liebt!-heit. Immer mehr Programme bieten die Mîglichkeit, fÅr die
@@ -2037,14 +2040,14 @@ Zwar lÑût sich nun Åber die UFSL--Schnittstelle ein Fontselektor
 auf!-rufen, doch hat diese Schnittstelle bereits eine Reihe von --- zum
 Teil inkompatiblen --- énderungen und Erweiterungen hinter sich. Daher
 gehen die meisten Programme heute davon aus, daû sie nur die
-ur!-sprÅng!-liche einfache (!nolink [UFSL-Schnittstelle]) zur VerfÅgung haben. Im
+ur!-sprÅng!-liche einfache UFSL-Schnittstelle zur VerfÅgung haben. Im
 Endeffekt bleiben also die Erweiterungen ungenutzt und wenn in einem
 Programm dann doch einmal ein etwas leistungsfÑhigerer Fontselektor
 benîtigt wird, dann geht man doch wieder dazu Åber, extra fÅr das Programm
 einen neuen Fontselektor zu schreiben. Etwas Åberspitzt formuliert wird
 hier also die Idee eines externen Fontselektors ad absurdum gefÅhrt !..
 
-Durch den ""Wildwuchs"" an der (!nolink [UFSL-Schnittstelle]) erschien es sinn!-voller,
+Durch den ""Wildwuchs"" an der UFSL-Schnittstelle erschien es sinn!-voller,
 einen klaren Trennstrich zu ziehen und eine komplett neue Schnittstelle
 zu entwickeln, die dann auch Åber einen neuen Cookie angeboten wird.
 
@@ -2484,7 +2487,7 @@ von (!V)xfsl_init(!v) geliefert wurde.
 Fontselektors beendet werden soll. Sei es dadurch, daû ein Font
 aus!-ge!-wÑhlt oder ""Abbruch"" angewÑhlt wurde, oder daû
 (!V)xfsl_event(!v) einen Feh!-ler meldete. Wenn schon der
-(!V)(!nolink [xfsl_init])(!v)--Aufruf fehlgeschlagen ist, darf (!V)xfsl_exit(!v) nicht
+(!V)xfsl_init(!v)--Aufruf fehlgeschlagen ist, darf (!V)xfsl_exit(!v) nicht
 aufgerufen werden (logisch, da man ja auch kein gÅl!-tiges Handle hat).
 
 Der Aufruf von (!V)xfsl_exit(!v) sollte auch bei Eintreffen der
@@ -2563,19 +2566,19 @@ Dabei gilt es zu beachten, daû der Fontselektor ebenfalls eine eigene
 verwendet. U.a. wird er fÅr diese Workstation auch (!V)vst_load_fonts()(!v)
 aufrufen (sofern ein GDOS installiert ist). Dies kann zu unerwarteten
 Resultaten fÅhren, wenn auf der Åbergebenen Workstation noch kein
-(!V)(!nolink [vst_load_fonts])()(!v) aufgerufen wurde und der Anwender im Fontselektor
-einen Font auswÑhlt, der erst nach einem (!V)(!nolink [vst_load_fonts])()(!v)--Aufruf
+(!V)vst_load_fonts()(!v) aufgerufen wurde und der Anwender im Fontselektor
+einen Font auswÑhlt, der erst nach einem (!V)vst_load_fonts()(!v)--Aufruf
 zur VerfÅgung steht!
 
 !smallskip
 
 Statt eines Workstation--Handles kann man aber auch einfach eine Null
 Åbergeben. Der Fontselektor wird den aktuellen Font dann aus den
-Åbergebenen Parametern (beim (!V)(!nolink [xfsl_input])(!v)--Aufruf) bzw. aus der
-(!V)xFSL_PAR(!v)--Struktur (beim (!V)(!nolink [xfsl_init])(!v)--Aufruf) ermitteln.
+Åbergebenen Parametern (beim (!V)xfsl_input(!v)--Aufruf) bzw. aus der
+(!V)xFSL_PAR(!v)--Struktur (beim (!V)xfsl_init(!v)--Aufruf) ermitteln.
 
 Der ausgewÑhlte Font wird dann (logischerweise) auch nur in den Parametern
-bzw. der (!V)(!nolink [xFSL_PAR])(!v)--Struktur zurÅckgegeben und der Aufrufer muû ihn
+bzw. der (!V)xFSL_PAR(!v)--Struktur zurÅckgegeben und der Aufrufer muû ihn
 dann selbst einstellen.
 
 !end_node
@@ -2631,7 +2634,7 @@ xpar.par_size=sizeof(xFSL_PAR);
 
 !item [(!V)pfi_size(!v)]
  Auch dieses Feld darf nicht Null sein, hier muû die Grîûe der
- (!V)(!nolink [PFONTINFO])(!v)--Struktur eingetragen werden, also
+ (!V)PFONTINFO(!v)--Struktur eingetragen werden, also
 !begin_quote
 !begin_verbatim
 xpar.pfi_size=sizeof(PFONTINFO);
@@ -2734,7 +2737,7 @@ nur
 !begin_itemize
  !item ''(!V)par_size(!v)'', die Grîûe der (!V)xFSL_PAR(!v)--Struktur selbst
  !item ''(!V)pfi_size(!v)'', die Grîûe der (!V)PFONTINFO(!v)--Struktur
- !item ''(!V)font(!v)'', der Zeiger auf die (!V)(!nolink [PFONTINFO])(!v)--Struktur
+ !item ''(!V)font(!v)'', der Zeiger auf die (!V)PFONTINFO(!v)--Struktur
 !end_itemize
 
 !end_node
@@ -2893,7 +2896,7 @@ Die Elemente im einzelnen:
 
 !item [(!V)fontsize(!v)]
  Die Grîûe des Fonts in Punkt (pt) oder 1/65536 Punkt
- (Typ ""(!V)(!nolink [fix31])(!v)""):
+ (Typ ""(!V)fix31(!v)""):
 !begin_quote
 !begin_verbatim
 union fsize
@@ -2908,7 +2911,7 @@ union fsize
 
 !item [(!V)fontwidth(!v)]
  Breite des Fonts in Punkt (pt) oder 1/65536 Punkt
- (Typ ""(!V)(!nolink [fix31])(!v)""):
+ (Typ ""(!V)fix31(!v)""):
 !begin_quote
 !begin_verbatim
 union fsize
@@ -2940,7 +2943,7 @@ union fsize
 
 !item [pairkern]
  Mit diesem Parameter kann das Pair--Kerning aus-- (0) oder eingeschaltet
- (1) werden, vgl. (!V)(!nolink [vst_kern])()(!v).
+ (1) werden, vgl. (!V)vst_kern()(!v).
 
 !item [(!V)fontattr(!v)]
  Dies sind die Fontattribute (Texteffekte), wie sie auch von der
@@ -2997,7 +3000,7 @@ union fsize
    TVA_TOP    !!  2  !!  an der Text-Oberkante
  !end_table
  Diese Werte entsprechen absichtlich (!I)nicht(!i) dem Parameter zur
- ver!-ti!-kalen Ausrichtung bei (!V)(!nolink [vst_alignment])()(!v)! Die dort
+ ver!-ti!-kalen Ausrichtung bei (!V)vst_alignment()(!v)! Die dort
  ver!-wen!-de!-ten Werte (""Zeichen!-unter!-kante"",
  ""Zeichen!-zellen!-unter!-kante"") sind fÅr den normalen Anwender wenig
  in!-tui!-tiv und sollten daher nicht Teil des User--Interfaces sein (was
@@ -3291,7 +3294,7 @@ gleich -32) auftreten, insbesondere kann (!V)xfsl_init(!v) auch den
 Wert (!V)EINVFN(!v) (-32) liefern, wenn der Fontselektor den erweiterten
 Aufruf nicht unterstÅtzt.
 
-Beim Aufruf (!V)(!nolink [xfsl_init])(!v) entsprechen positive RÅckgabewerte dem
+Beim Aufruf (!V)xfsl_init(!v) entsprechen positive RÅckgabewerte dem
 Fenster!-handle des Fontselektors (0 bedeutet, daû der Fontselektor als
 mo!-daler Dialog geîffnet wurde).
 
@@ -3330,7 +3333,7 @@ typedef struct /* Special type for EventMulti */
 } EVENT;
 !end_verbatim
 !end_quote
-Die Elemente der Struktur entsprechen denen des (!V)(!nolink [evnt_multi])()(!v)--Aufrufs.
+Die Elemente der Struktur entsprechen denen des (!V)evnt_multi()(!v)--Aufrufs.
 Auch die Reihenfolge der Parameter ist --- bis auf wenige Ausnahmen ---
 identisch. Das Feld ''(!V)ev_mwich(!v)'' enthÑlt die aufgetretenen Events
 in der gleichen Kodierung wie ''(!V)ev_mflags(!v)''.
@@ -3408,12 +3411,12 @@ void call_xfsl (void)
 !end_quote
 
 Mit den beiden (!V)memset(!v)--Aufrufen werden alle Elemente der
-Strukturen (!V)(!nolink [xFSL_PAR])(!v) und (!V)(!nolink [PFONTINFO])(!v) auf Null gesetzt.
+Strukturen (!V)xFSL_PAR(!v) und (!V)PFONTINFO(!v) auf Null gesetzt.
 Anschlieûend werden einige un!-be!-dingt nîtige Werte eingetragen:
 !begin_itemize
  !item die Grîûen der beiden Strukturen (!V)xFSL_PAR(!v) und
-       (!V)(!nolink [PFONTINFO])(!v)
- !item die Adresse der (!V)(!nolink [PFONTINFO])(!v)--Struktur wird in der
+       (!V)PFONTINFO(!v)
+ !item die Adresse der (!V)PFONTINFO(!v)--Struktur wird in der
        (!V)xFSL_PAR(!v)--Struktur eingetragen
  !item die Schriftfarbe wird auf schwarz gesetzt (dies kînnte man auch
        weglassen, aber normalerweise wird man ja in schwarzer Schrift
@@ -3583,15 +3586,16 @@ Der Speicherbedarf dieser Union betrÑgt vier Bytes, da der Typ fix31
 vier Bytes groû ist. Man (!I)kînnte(!i) nun dem Element ''(!V)size31(!v)''
 eine Grîûen!-an!-ga!-be in 1/65536 Punkt zuweisen und dann den Wert in
 ganzen Punkt aus dem Element ''(!V)size(!v)'' auslesen --- dies ist aber
-nicht empfehlenswert, da bei der Umrechnung (!V)(!nolink [fix31])(!v) nach pt immer
+nicht empfehlenswert, da bei der Umrechnung (!V)fix31(!v) nach pt immer
 gerundet werden sollte, s.u.
 
 !smallskip
 
-!label fix31
+!label Data-type fix31
+!index fix31
 (!U)(!V)fix31(!v)(!u)
 
-Der Datentyp (!V)(!nolink [fix31])(!v) ist eine Festkommazahl, bei dem die oberen
+Der Datentyp (!V)fix31(!v) ist eine Festkommazahl, bei dem die oberen
 16 Bit den vorzeichenbehafteten Vorkomma-Anteil darstellen und die
 unteren 16 Bit den vorzeichenlosen Nachkomma-Anteil. Er wird
 ausschlieûlich fÅr Grîûenangaben von Fonts verwendet, die damit auf
@@ -3616,7 +3620,7 @@ den Fontselektor, obenauf liegt.
 
 # ------------------------------------------------------------------------
 !begin_node Pure C und ''cdecl''
-!raw [stg] @alias "cdecl"
+!label cdecl
 Pure C Åbergibt die Parameter an Funktionen normalerweise in Re!-gi!-stern.
 FÅr eine öbergabe Åber den Stack muû entweder das SchlÅs!-sel!-wort
 ""(!V)cdecl(!v)"" verwendet werden (wie im Includefile (!V)XFSL.H(!v)
@@ -3632,7 +3636,7 @@ Erweiterung und wird daher bei gesetztem Compilerschalter ""(!V)-A(!v)""
 
 # ########################################################################
 !begin_node Revisions--History
-!raw [stg] @alias History
+#!raw [stg] @alias History
 (!B)Revision 4(!b)
 !begin_itemize
  !item Aufgrund eines kleinen Designfehlers in den Ñlteren Revisionen,
@@ -3641,17 +3645,17 @@ Erweiterung und wird daher bei gesetztem Compilerschalter ""(!V)-A(!v)""
        sollte in der Praxis kein Problem darstellen, da der Fontselektor
        Auf!-rufe nach dem alten Schema mit einem Fehler quittieren wird.
        Die alte Revision 3 wird im Laufe der Zeit verschwinden.
- !item neue Parameter in der (!V)(!nolink [PFONTINFO])(!v)--Struktur:
+ !item neue Parameter in der (!V)PFONTINFO(!v)--Struktur:
        !begin_itemize
         !item Text--Hintergrundfarbe (''(!V)backcol(!v)'')
-        !item (!nolink [Textausrichtung]) (''(!V)halign(!v)'' und ''(!V)valign(!v)'')
-        !item (!nolink [Textrotation]) (''(!V)rotation(!v)'')
+        !item Textausrichtung (''(!V)halign(!v)'' und ''(!V)valign(!v)'')
+        !item Textrotation (''(!V)rotation(!v)'')
         !item Angabe von Zeichen, die der ausgewÑhlte Font unbedingt
               ent!-hal!-ten soll (''(!V)validtype(!v)'' und
               ''(!V)validchars(!v)'')
        !end_itemize
- !item die (!V)(!nolink [PFONTINFO])(!v)--Struktur wird auch bei RÅckgabe
-       (!V)(!nolink [xFS_STOP])(!v) mit den Werten des zuletzt im Fontselektor
+ !item die (!V)PFONTINFO(!v)--Struktur wird auch bei RÅckgabe
+       (!V)xFS_STOP(!v) mit den Werten des zuletzt im Fontselektor
        ausgewÑhlten Fonts gefÅllt
  !item Codierung der Fontflags geÑndert (feinere Unterscheidung der
        Vektorformate)
@@ -3729,13 +3733,13 @@ Die NamensÑnderung wurde vollzogen, um Ver!-wechs!-lungen zu vermeiden.
 
 !raw [stg] @index "Calvino"
 !item [Calvino] von Dirk Haun (!nl)
-Zusammen mit HuGo! der erste Fontselektor mit (!nolink [xFSL--Schnittstelle]). Auch
-Calvino unterstÅtzt noch die einfache (!nolink [UFSL--Schnittstelle]).
+Zusammen mit HuGo! der erste Fontselektor mit xFSL--Schnittstelle. Auch
+Calvino unterstÅtzt noch die einfache UFSL--Schnittstelle.
 
 !item [FONT_SEL und FONT_PAL] von Christian Grunenberg (!nl)
 Diese beiden Programme arbeiten auf Drag&Drop--Basis, sie unter!-stÅtzen
-also weder die UFSL-- noch die (!nolink [xFSL--Schnittstelle]), dafÅr aber das
-(!nolink [Font--Protokoll]). (!V)FONT_SEL(!v) ist ein Fontselektor, (!V)FONT_PAL(!v)
+also weder die UFSL-- noch die xFSL--Schnittstelle, dafÅr aber das
+Font--Protokoll. (!V)FONT_SEL(!v) ist ein Fontselektor, (!V)FONT_PAL(!v)
 eine Fontpalette (mit integriertem Fontselektor).
 !end_description
 
@@ -3748,7 +3752,7 @@ Folgende Programme unterstÅtzen einen externen Fontselektor (Stand
 16.08.1998, alle Angaben und E-Mail-Adressen ohne GewÑhr):
 
 !begin_table [l|l|l|c|c]
- Program       !! Category            !!  Author              !! (!nolink [UFSL]) !! xFSL
+ Program       !! Category            !!  Author              !! UFSL !! xFSL
 !hline
  800XL-Deejay  !! Laufwerksemulator   !! Kolja Koischwitz     !! +   !!
  APP_List      !! Systemutility       !! Ralf Zimmermann      !! +   !!
@@ -3945,7 +3949,7 @@ als modalen Dialog aufrufen. Die Empfehlung lautet daher, eine minimale
 UFSL--UnterstÅtzung einzubauen (nur als modaler Dialog) und dafÅr die
 xFSL--Schnittstelle mîglichst weitgehend zu implementieren,
 da zu erwarten steht, daû gerade die --- nun endlich genormten ---
-Er!-wei!-te!-rungen gegenÅber der (!nolink [UFSL-Schnittstelle]) von den Programmen
+Er!-wei!-te!-rungen gegenÅber der UFSL-Schnittstelle von den Programmen
 ver!-wen!-det werden sollen.
 
 Ein Fontselektor sollte mîglichst die folgenden zusÑtzlichen Features
@@ -3955,7 +3959,7 @@ bieten:
       Insbesondere ist damit gemeint, daû nicht nur eine Grîûe
       aus!-ge!-wÑhlt, sondern bei Vektorfonts auch die Zwischengrîûen
       ein!-ge!-stellt werden kînnen.
-!item (!nolink [fix31])--UnterstÅtzung (!nl)
+!item fix31--UnterstÅtzung (!nl)
       FÅr einige Anwendungen reicht die Einstellung der Fontgrîûe in
       Punkt nicht aus, daher sollte auch eine Einstellung in 1/65536 Punkt
       mîglich sein.

--- a/xbios/bildscrm/vsetmode.ui
+++ b/xbios/bildscrm/vsetmode.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node Vsetmode
-!html_name Vsetmode
+#!html_name Vsetmode
 
 (!begin_liste) [Availability]
 
@@ -67,7 +67,7 @@ VgetRGB ~ VsetRGB ~ VsetMask
 (!ende_liste)
 
 !begin_node Bindings for Vsetmode
-!html_name Bindings_for_Vsetmode
+#!html_name Bindings_for_Vsetmode
 !ignore_index
 (!begin_liste) [Assembler:]
 !item [C:]
@@ -90,7 +90,7 @@ addq.l    #4,sp         ; Correct stack
 
 
 !begin_node Vsetmode
-!html_name Vsetmode
+#!html_name Vsetmode
 
 (!begin_liste) [Beschreibung]
 
@@ -154,7 +154,7 @@ VgetRGB ~ VsetRGB ~ VsetMask
 (!ende_liste)
 
 !begin_node Bindings fÅr Vsetmode
-!html_name Bindings_for_Vsetmode
+#!html_name Bindings_for_Vsetmode
 !ignore_index
 (!begin_liste) [Assembler:]
 !item [C:]

--- a/xbios/centscrn/centscrn.u
+++ b/xbios/centscrn/centscrn.u
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node CENTScreen XBIOS extension
-!html_name CENTScreen_XBIOS_extension.html
+!html_name CENTScreen_XBIOS_extension
 
 !begin_xlist [ù MultiMon ] !compressed
 !item [ù MultiMon]  Multisynchro mode.
@@ -33,7 +33,7 @@ not routines of the operating system.
 !else
 
 !begin_node CENTScreen-XBIOS-Erweiterung
-!html_name CENTScreen_XBIOS_extension.html
+!html_name CENTScreen_XBIOS_extension
 
 !begin_xlist [ù MultiMon ] !compressed
 !item [ù MultiMon]  Multisynchro Mode

--- a/xbios/interrpt/jenabint.ui
+++ b/xbios/interrpt/jenabint.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node Jenabint
-!html_name Jenabint
+#!html_name Jenabint
 (!begin_liste) [Availability]
 
 !item [Name:]
@@ -79,7 +79,7 @@ addq.l    #4,sp         ; Correct stack
 
 
 !begin_node Jenabint
-!html_name Jenabint
+#!html_name Jenabint
 (!begin_liste) [Beschreibung]
 
 !item [Name:]

--- a/xbios/laufwerk/metastar.ui
+++ b/xbios/laufwerk/metastar.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node Metastartaudio
-!html_name Metastartaudio
+#!html_name Metastartaudio
 
 (!begin_liste) [Availability]
 
@@ -74,7 +74,7 @@ lea       $A(sp),sp    ; Call XBIOS
 
 
 !begin_node Metastartaudio
-!html_name Metastartaudio
+#!html_name Metastartaudio
 
 (!begin_liste) [Beschreibung]
 

--- a/xbios/pci_bios/read_config_byte.ui
+++ b/xbios/pci_bios/read_config_byte.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node read_config_byte
-!html_name read_config_byte
+#!html_name read_config_byte
 
 (!begin_liste) [Availability]
 
@@ -73,7 +73,7 @@ addq.l    #11,sp        ; Correct stack
 
 
 !begin_node read_config_byte
-!html_name read_config_byte
+#!html_name read_config_byte
 
 (!begin_liste) [Beschreibung]
 

--- a/xbios/pci_bios/read_config_longword.ui
+++ b/xbios/pci_bios/read_config_longword.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node read_config_longword
-!html_name read_config_longword
+#!html_name read_config_longword
 
 (!begin_liste) [Availability]
 
@@ -72,7 +72,7 @@ addq.l    #11,sp        ; Correct stack
 
 
 !begin_node read_config_longword
-!html_name read_config_longword
+#!html_name read_config_longword
 
 (!begin_liste) [Beschreibung]
 

--- a/xbios/pci_bios/read_config_word.ui
+++ b/xbios/pci_bios/read_config_word.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node read_config_word
-!html_name read_config_word
+#!html_name read_config_word
 
 (!begin_liste) [Availability]
 
@@ -73,7 +73,7 @@ addq.l    #11,sp        ; Correct stack
 
 
 !begin_node read_config_word
-!html_name read_config_word
+#!html_name read_config_word
 
 (!begin_liste) [Beschreibung]
 

--- a/xbios/pci_bios/write_config_byte.ui
+++ b/xbios/pci_bios/write_config_byte.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node write_config_byte
-!html_name write_config_byte
+#!html_name write_config_byte
 
 (!begin_liste) [Availability]
 
@@ -74,7 +74,7 @@ addq.l    #8,sp         ; Correct stack
 
 
 !begin_node write_config_byte
-!html_name write_config_byte
+#!html_name write_config_byte
 
 (!begin_liste) [Beschreibung]
 

--- a/xbios/pci_bios/write_config_longword.ui
+++ b/xbios/pci_bios/write_config_longword.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node write_config_longword
-!html_name write_config_longword
+#!html_name write_config_longword
 
 (!begin_liste) [Availability]
 
@@ -74,7 +74,7 @@ addq.l    #11,sp        ; Correct stack
 
 
 !begin_node write_config_longword
-!html_name write_config_longword
+#!html_name write_config_longword
 
 (!begin_liste) [Beschreibung]
 

--- a/xbios/pci_bios/write_config_word.ui
+++ b/xbios/pci_bios/write_config_word.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node write_config_word
-!html_name write_config_word
+#!html_name write_config_word
 
 (!begin_liste) [Availability]
 
@@ -74,7 +74,7 @@ addq.l    #9,sp         ; Correct stack
 
 
 !begin_node write_config_word
-!html_name write_config_word
+#!html_name write_config_word
 
 (!begin_liste) [Beschreibung]
 

--- a/xbios/sound/startrac.ui
+++ b/xbios/sound/startrac.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node StarTrack
-!html_name StarTrack
+#!html_name StarTrack
 
 (!begin_liste) [Availability]
 
@@ -143,7 +143,7 @@ Sound routines
 
 
 !begin_node StarTrack
-!html_name StarTrack
+#!html_name StarTrack
 
 (!begin_liste) [Beschreibung]
 

--- a/xbios/spezial/janus.ui
+++ b/xbios/spezial/janus.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node Janus
-!html_name Janus
+#!html_name Janus
 
 (!begin_liste) [Availability]
 
@@ -48,7 +48,7 @@ Special commands
 
 
 !begin_node Bindings for Janus
-!html_name Bindings_for_Janus
+#!html_name Bindings_for_Janus
 
 !ignore_index
 (!begin_liste) [Implementierung:]
@@ -72,7 +72,7 @@ addq.l    #4,sp         ; Correct stack
 
 
 !begin_node Janus
-!html_name Janus
+#!html_name Janus
 
 (!begin_liste) [Beschreibung]
 
@@ -118,7 +118,7 @@ Spezialbefehle
 
 
 !begin_node Bindings fÅr Janus
-!html_name Bindings_for_Janus
+#!html_name Bindings_for_Janus
 
 !ignore_index
 (!begin_liste) [Implementierung:]

--- a/xbios/spezial/puntaes.ui
+++ b/xbios/spezial/puntaes.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node Puntaes
-!html_name Puntaes
+#!html_name Puntaes
 (!begin_liste) [Availability]
 
 !item [Name:]
@@ -47,7 +47,7 @@ Special commands
 
 
 !begin_node Bindings for Puntaes
-!html_name Bindings_for_Puntaes
+#!html_name Bindings_for_Puntaes
 !ignore_index
 (!begin_liste) [Assembler:]
 !item [C:]
@@ -69,7 +69,7 @@ addq.l    #2,sp        ; Correct stack
 
 
 !begin_node Puntaes
-!html_name Puntaes
+#!html_name Puntaes
 (!begin_liste) [Beschreibung]
 
 !item [Name:]

--- a/xbios/startrac/clkdivid.ui
+++ b/xbios/startrac/clkdivid.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node clkdivide
-!html_name clkdivide
+#!html_name clkdivide
 
 (!begin_liste) [Availability]
 
@@ -81,7 +81,7 @@ Sound routines
 
 
 !begin_node Bindings for clkdivide
-!html_name Bindings_for_clkdivide
+#!html_name Bindings_for_clkdivide
 
 !ignore_index
 (!begin_liste) [Assembler:]
@@ -104,7 +104,7 @@ addq.l    #6,sp        ; Correct stack
 
 
 !begin_node clkdivide
-!html_name clkdivide
+#!html_name clkdivide
 
 (!begin_liste) [Beschreibung]
 
@@ -184,7 +184,7 @@ Soundroutinen
 
 
 !begin_node Bindings fÅr clkdivide
-!html_name Bindings_for_clkdivide
+#!html_name Bindings_for_clkdivide
 
 !ignore_index
 (!begin_liste) [Assembler:]

--- a/xbios/startrac/dsp_host.ui
+++ b/xbios/startrac/dsp_host.ui
@@ -2,7 +2,7 @@
 
 
 !begin_node dsp_hostcommand
-!html_name dsp_hostcommand
+#!html_name dsp_hostcommand
 
 (!begin_liste) [Availability]
 
@@ -41,7 +41,7 @@ Sound routines
 
 
 !begin_node Bindings for dsp_hostcommand
-!html_name Bindings_for_dsp_hostcommand
+#!html_name Bindings_for_dsp_hostcommand
 
 !ignore_index
 (!begin_liste) [Assembler:]
@@ -64,7 +64,7 @@ addq.l    #6,sp         ; Correct stack
 
 
 !begin_node dsp_hostcommand
-!html_name dsp_hostcommand
+#!html_name dsp_hostcommand
 
 (!begin_liste) [Beschreibung]
 
@@ -103,7 +103,7 @@ Soundroutinen
 
 
 !begin_node Bindings fÅr dsp_hostcommand
-!html_name Bindings_for_dsp_hostcommand
+#!html_name Bindings_for_dsp_hostcommand
 
 !ignore_index
 (!begin_liste) [Assembler:]

--- a/xbios/structures/IOREC.ui
+++ b/xbios/structures/IOREC.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node IOREC
-!html_name IOREC
+#!html_name IOREC
 
 !begin_verbatim
 typedef struct
@@ -30,7 +30,7 @@ See also: Iorec
 !else
 
 !begin_node IOREC
-!html_name IOREC
+#!html_name IOREC
 
 Diese Struktur ist wie folgt definiert:
 

--- a/xbios/structures/PCI_RSC_DESC.ui
+++ b/xbios/structures/PCI_RSC_DESC.ui
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node PCI_RSC_DESC
-!html_name PCI_RSC_DESC
+#!html_name PCI_RSC_DESC
 
 !begin_verbatim
 typedef struct
@@ -128,7 +128,7 @@ See also: get_resource
 !else
 
 !begin_node PCI_RSC_DESC
-!html_name PCI_RSC_DESC
+#!html_name PCI_RSC_DESC
 
 !begin_verbatim
 typedef struct


### PR DESCRIPTION
When nodes are merged, that means that there html output is written to the same output file as the parent node, so having a !html_name command in them only makes udo spit out warnings/errors.