### PR TITLE
Add latest changes to Ssystem() function

### DIFF
--- a/gemdos/system/ssystem.ui
+++ b/gemdos/system/ssystem.ui
@@ -146,9 +146,10 @@ Binary major CPU ID
 Reserved for future definition
 !end_xlist
 
-The major ID identifies a particular series of processors. Currently only a
-value of $00 is defined and it is assigned to Motorola 68k series. Other
-values of this field are reserved for future definition.
+The major ID identifies a particular series of processors. A value of
+$00 is assigned to the Motorola 68k series and since kernel version 1.19
+a value of $01 is assigned to the ColdFire processors. Other values of this
+field are reserved for future definition.
 
 The minor CPU ID interpretation depends on the major ID. For 68k series,
 values are as follows:
@@ -160,6 +161,15 @@ values are as follows:
 0x1e !! 68030
 0x28 !! 68040
 0x3c !! 68060
+!end_table
+
+For the ColdFire series:
+
+!begin_table
+0x00 !! isa_a
+0X01 !! isa_a+
+0X02 !! isa_b
+0X03 !! isa_c
 !end_table
 
 This is not the same as the (!link [_CPU][Cookie, _CPU]) cookie value. The


### PR DESCRIPTION
Information returned by Ssystem() mode S_OSCOMPILE
for the ColdFire processors.