### PR TITLE
Correct Shutdown() system call parameter mode values

### DIFF
--- a/gemdos/system/shutdown.ui
+++ b/gemdos/system/shutdown.ui
@@ -16,9 +16,12 @@ int32_t Shutdown ( int32_t mode );
 The function Shutdown kills all processes, syncs file-systems then halts or
 reboots the system.
 
-!label SHUT_HALT
-On (!I)mode(!i) equal to SHUT_HALT (0L), the system will shut down, then
-enter a halted condition.
+!label SHUT_POWER
+On (!I)mode(!i) equal to SHUT_POWER (0L), the system will turn the power
+off. The only hardware that supports it at present is CT60 and the FireBee.
+If the hardware does not support it, SHUT_HALT will be performed. SHUT_POWER
+mode is recognized as of FreeMiNT version 1.16a; older versions of the kernel
+will treat the SHUT_POWER mode as SHUT_COLD.
 
 !label SHUT_BOOT
 On (!I)mode(!i) equal to SHUT_BOOT (1L), the system will reboot the machine
@@ -31,12 +34,9 @@ will be performed. SHUT_COLD mode is recognized as of FreeMiNT version
 1.15.5; older versions of the kernel will treat the SHUT_COLD mode as
 SHUT_BOOT.
 
-!label SHUT_POWER
-On (!I)mode(!i) equal to SHUT_POWER (3L), the system will turn the power
-off. The only hardware that supports it at present is CT60. If the hardware
-does not support it, SHUT_HALT will be performed. SHUT_POWER mode is
-recognized as of FreeMiNT version 1.16a; older versions of the kernel will
-treat the SHUT_POWER mode as SHUT_COLD.
+!label SHUT_HALT
+On (!I)mode(!i) equal to SHUT_HALT (3L), the system will shut down, then
+enter a halted condition.
 
 All other values of (!I)mode(!i) are reserved for future definition.
 
@@ -98,9 +98,12 @@ int32_t Shutdown ( int32_t mode );
 This function kills all processes, syncs filesystems then halts or reboots
 the system.
 
-!label SHUT_HALT
-On (!I)mode(!i) equal to SHUT_HALT (0L), the system will shutdown 
-then enter a halted condition.
+!label SHUT_POWER
+On (!I)mode(!i) equal to SHUT_POWER (0L), the system will turn the power
+off. The only hardware that supports it at present is CT60 and the FireBee.
+If the hardware does not support it, SHUT_HALT will be performed. SHUT_POWER
+mode is recognized as of FreeMiNT version 1.16a; older versions of the kernel
+will treat the SHUT_POWER mode as SHUT_COLD.
 
 !label SHUT_BOOT
 On (!I)mode(!i) equal to SHUT_BOOT (1L), the system will 
@@ -114,13 +117,9 @@ SHUT_COLD mode is recognized as of FreeMiNT version 1.15.5,
 older versions of the kernel will treat the SHUT_COLD as 
 SHUT_BOOT.
 
-!label SHUT_POWER
-On (!I)mode(!i) equal to SHUT_POWER (3L), the system will 
-turn power off. The only hardware that supports it is atm. CT60. If 
-hardware does not support it, SHUT_HALT will be performed. (!nl)
-SHUT_POWER mode is recognized as of FreeMiNT version 1.16a, 
-older versions of the kernel will treat the SHUT_POWER as 
-SHUT_COLD.
+!label SHUT_HALT
+On (!I)mode(!i) equal to SHUT_HALT (3L), the system will shut down, then
+enter a halted condition.
 
 All other values of mode are reserved for future definition.
 


### PR DESCRIPTION
SHUT_HALT should be 3L and SHUT_POWER 0L.
See: https://github.com/freemint/freemint/blob/master/sys/dos.c#L719-L725

Add the FireBee as hardware that supports SHUT_POWER mode.