### PR TITLE
evnt_button: Correct some info

### DIFF
--- a/gem/aes/evnt_/evnt_button.ui
+++ b/gem/aes/evnt_/evnt_button.ui
@@ -63,20 +63,18 @@ With a pressed key the corresponding bit will be set
 !end_xlist
 (!B)Note:(!b) As of PC-(!nolink [GEM])/3 the
 (!link [event functions][Event library]) support only one mouse button.
-Although officially (!I)not(!i) docu!-mented, it is also possible to
-interrogate both mouse buttons independently of each other. The following is
-used by the Atari desktop, for instance, and works as of (!nolink [TOS]) 1.0:
 
-ev_bclicks += 0x100;
+(!B)Note 2:(!b) Specifying both left and right buttons in ev_bmask:
 
-In this case one waits for the following event: (!nl)
-               (ev_bstate & ev_bmask) != (*ev_bbutton & ev_bmask)
+        ev_button(1,3,3,...
 
-Furthermore, logically OR'ing (!I)ev_bmask(!i) with 0x100 will make the call
-return when independent buttons have been pressed; thus a (!I)ev_bmask(!i)
-value of 0x03 will return when both the left and right mouse buttons are
-pressed, and a value of 0x103 causes the call to return when either button
-is pressed.
+will wait until *both* buttons are pressed simultaneously.  If you wish to wait
+for *either* button to be pressed, then you must set bit 8 of *ev_bclicks*:
+
+        ev_button(0x0101,3,3,...
+
+This was documented in the December 1992 issue of ATARI.RSC (the developer's
+newsletter) and is true for all releases of Atari TOS.
 
 !item [(!nolink [Return]) value:]
 The function returns the number of mouse clicks that were actually made, or,


### PR DESCRIPTION
Some of the info about evnt_button() [which is also referenced in
evnt_multi()] is unclear, and some is wrong.

Change suggested by Roger Burrows (@anodynesoftware)