### PR TITLE
Add BSIM BIOS extension

### DIFF
--- a/bios/bios.u
+++ b/bios/bios.u
@@ -246,5 +246,6 @@ GEMDOS-Fehlermeldungen
 !include bios/cookie/cookie.u
 !include bios/vt52.u
 !include bios/xbra.u
+!include bios/bios_bsim.u
 !include bios/bios_f.u
 !include bios/structures/structures.u

--- a/bios/bios_bsim.u
+++ b/bios/bios_bsim.u
@@ -1,0 +1,103 @@
+!iflang [english]
+
+!begin_node BSIM-BIOS-Extension
+!html_name BSIM-BIOS-Extension
+
+!label BSIM
+
+The basic idea of the Drive-B-Simulator is to read a floppy disk into memory
+and operate it as a RAM-disk. The 'write disk' function writes the RAM-disk
+back to the disk. A 'swap mode' allows the program to work with applications
+that stubbornly access drive A.
+
+!begin_xlist [x drv_change  ] !compressed
+!item [(!bullet) bsim_id]
+Check if BSIM is available
+!item [(!bullet) drv_change]
+Swap drives
+!item [(!bullet) drvprotec]
+Get/set software write-protection for drives
+!item [(!bullet) dstate]
+Get details about the drive
+!item [(!bullet) kill_disk]
+Remove disk from memory
+!item [(!bullet) load_disk]
+Load disk into memory
+!item [(!bullet) save_disk]
+Save to disk
+!end_xlist
+
+(!B)Note:(!b) Drive-B-Simulator uses the same XBRA ID as BlitSim ('BSIM').
+
+(!B)Configuration file:(!b)
+
+The config file BSTAT.INF is an array of 18 bytes. The following apply:
+!begin_xlist !compressed [Offset]
+!item [Offset]
+Meaning
+!item [0..15]
+Write lock status (0 or 1) for each drive, from byte 0=A to byte 15=P
+!item [16]
+Load disk at startup (0 or 1)
+!item [17]
+Swap drives at startup (0 or 1)
+!end_xlist
+
+!else
+
+!begin_node BSIM-BIOS-Erweiterungen
+!html_name BSIM-BIOS-Erweiterungen
+
+!label BSIM
+
+Die Grundidee des Drive-B-Simulator war, eine Diskette in den Speicher einzulesen
+und als RAM-Disk zu betreiben. Die Funktion 'Diskette schreiben' schreibt die
+RAM-Disk auf eine Diskette zur(!uumlaut)ck. Mit der Einf(!uumlaut)hrung des
+'Swap-Modus' arbeitet das Programm auch mit Anwendungen, die stur auf Laufwerk A
+zugreifen.
+
+!begin_xlist [x drv_change  ] !compressed
+!item [(!bullet) bsim_id]
+Ermittelt, ob BSIM verf(!uumlaut)gbar ist
+!item [(!bullet) drv_change]
+Tauscht Laufwerke
+!item [(!bullet) drvprotec]
+Sch(!uumlaut)tzt Laufwerke
+!item [(!bullet) dstate]
+Get details about the drive
+!item [(!bullet) kill_disk]
+L(!oumlaut)scht Diskette
+!item [(!bullet) load_disk]
+L(!aumlaut)dt eine Diskette in den Speicher
+!item [(!bullet) save_disk]
+Schreibt Diskette.
+!end_xlist
+
+(!B)Note:(!b) Drive-B-Simulator uses the same XBRA ID as BlitSim ('BSIM').
+
+(!B)Configuration file:(!b)
+
+The config file BSTAT.INF is an array of 18 bytes. The following apply:
+!begin_xlist !compressed [Offset]
+!item [Offset]
+Meaning
+!item [0..15]
+Write lock status (0 or 1) for each drive, from byte 0=A to byte 15=P
+!item [16]
+Load disk at startup (0 or 1)
+!item [17]
+Swap drives at startup (0 or 1)
+!end_xlist
+
+!endif
+
+!include bios/bsim/bsim_id.ui
+!include bios/bsim/drv_change.ui
+!include bios/bsim/drvprotec.ui
+!include bios/bsim/dstate.ui
+!include bios/bsim/kill_disk.ui
+!include bios/bsim/load_disk.ui
+!include bios/bsim/save_disk.ui
+
+!end_node
+

--- a/bios/bsim/bsim_id.ui
+++ b/bios/bsim/bsim_id.ui
@@ -1,0 +1,81 @@
+!iflang [english]
+
+!begin_node bsim_id
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)BSIM id(!ldouble) - Check if BSIM is available
+!item [Opcode:]
+300 (0x012c)
+!item [Syntax:]
+(!link [See 'Bindings for bsim_id'] [Bindings for bsim_id])
+!item [Description:]
+The (!nolink [BIOS]) routine bsim_id checks if BSIM is available.
+
+!item [(!nolink [Return]) value:]
+The function returns 0x4253494D ('(!nolink [BSIM])') if BSIM is available.
+
+!item [Availability:] Drive-B-Simulator.
+
+!item [See also:]    (!link [Binding] [Bindings for bsim_id])
+
+(!ende_liste)
+
+
+!begin_node Bindings for bsim_id
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.w    #$12C,-(sp)   ; Offset 0
+trap      #13           ; Call BIOS
+addq.l    #2,sp         ; Correct stack
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(300)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node bsim_id
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)BSIM id(!ldouble) - ermittelt, ob BSIM verf(!uumlaut)gbar ist.
+!item [Biosnummer:]
+300 (0x012c)
+!item [Deklaration:]
+Bindings f(!uumlaut)r bsim_id
+!item [Beschreibung:]
+Die Funktion ermittelt die BSIM id.
+!item [Ergebnis:]
+Wenn BSIM installiert ist, gibt die Funktion 0x4253494D ('(!nolink [BSIM])') zur(!uumlaut)ck.
+
+!item [Verf(!uumlaut)gbar:] Drive-B-Simulator.
+
+!item [Querverweis:]    (!link [Binding] [Bindings f(!uumlaut)r bsim_id])
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r bsim_id
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.w    #$12C,-(sp)   ; Offset 0
+trap      #13           ; BIOS aufrufen
+addq.l    #2,sp         ; Stack korrigieren
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(300)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!endif
+

--- a/bios/bsim/drv_change.ui
+++ b/bios/bsim/drv_change.ui
@@ -1,0 +1,112 @@
+!iflang [english]
+
+!begin_node drv_change
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Drive change(!ldouble) - Swap drives
+!item [Opcode:]
+304 (0x0130)
+!item [Syntax:]
+(!link [See 'Bindings for drv_change'] [Bindings for drv_change])
+!item [Description:]
+The (!nolink [BIOS]) routine drv_change allows to swap drives. The (!I)data(!i)
+argument is as follows:
+!begin_xlist !compressed [-1:]
+!item [0:]
+Normal
+!item [1:]
+Swapped
+!item [-1:]
+Status
+!end_xlist
+
+!item [(!nolink [Return]) value:]
+The function can return the following results in D0:
+!begin_xlist !compressed [0:]
+!item [0:]
+Normal
+!item [1:]
+Swapped
+!end_xlist
+
+!item [Availability:] Drive-B-Simulator.
+
+!item [See also:]    (!link [Binding] [Bindings for drv_change])
+
+(!ende_liste)
+
+
+!begin_node Bindings for drv_change
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.w    #data,-(sp)   ; Offset 2
+move.w    #$130,-(sp)   ; Offset 0
+trap      #13           ; Call BIOS
+addq.l    #4,sp         ; Correct stack
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(304,W:data%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node drv_change
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Drive change(!ldouble) - tauscht Drives.
+!item [Biosnummer:]
+304 (0x0130)
+!item [Deklaration:]
+Bindings f(!uumlaut)r drv_change
+!item [Beschreibung:]
+Die Funktion tauscht Drives. F(!uumlaut)r (!I)data(!i) gilt:
+!begin_xlist !compressed [-1:]
+!item [0:]
+Normal
+!item [1:]
+Tauschen
+!item [-1:]
+Status holen
+!end_xlist
+!item [Ergebnis:]
+Die Funktion kann folgende R(!uumlaut)ckgabewerte liefern in D0:
+!begin_xlist !compressed [E_OK:]
+!item [0:]
+Normal
+!item [1:]
+Tauschen
+!end_xlist
+
+!item [Verf(!uumlaut)gbar:] Drive-B-Simulator.
+
+!item [Querverweis:]    (!link [Binding] [Bindings f(!uumlaut)r drv_change])
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r drv_change
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.w    #data,-(sp)   ; Offset 2
+move.w    #$130,-(sp)   ; Offset 0
+trap      #13           ; BIOS aufrufen
+addq.l    #4,sp         ; Stack korrigieren
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(304,W:data%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!endif
+

--- a/bios/bsim/drvprotec.ui
+++ b/bios/bsim/drvprotec.ui
@@ -1,0 +1,87 @@
+!iflang [english]
+
+!begin_node drvprotec
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Drive protection(!ldouble) - Write lock settings
+!item [Opcode:]
+305 (0x0131)
+!item [Syntax:]
+(!link [See 'Bindings for drvprotec'] [Bindings for drvprotec])
+!item [Description:]
+The (!nolink [BIOS]) routine drvprotec gets or sets the write-protected drive
+status. The (!I)prtdrv(!i) argument is a bit-vector for the protected drives
+(bit 0=A, bit 1=B...), or -1 to inquire the current status.
+
+!item [(!nolink [Return]) value:]
+The function returns a bit-vector for the protected drives.
+
+!item [Availability:] Drive-B-Simulator.
+
+!item [See also:]    (!link [Binding] [Bindings for drvprotec])
+
+(!ende_liste)
+
+
+!begin_node Bindings for drvprotec
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.l    #prtdrv,-(sp) ; Offset 2
+move.w    #$131,-(sp)   ; Offset 0
+trap      #13           ; Call BIOS
+addq.l    #6,sp         ; Correct stack
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(305,L:prtdrv%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node drvprotec
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Drive protection(!ldouble) - sch(!uumlaut)tzt Laufwerke.
+!item [Biosnummer:]
+305 (0x0131)
+!item [Deklaration:]
+Bindings f(!uumlaut)r drvprotec
+!item [Beschreibung:]
+Die Funktion sch(!uumlaut)tzt Laufwerke. (!I)ptrdrv(!i) ist ein Bitvektor f(!uumlaut)r
+gesch(!uumlaut)tzte Laufwerke (Bit 0=A, Bit 1=B...), oder -1 (Status holen).
+!item [Ergebnis:]
+Die Funktion liefert als Ergebnis einen Bitvektor f(!uumlaut)r die gesch(!uumlaut)tzte
+Laufwerke.
+
+!item [Verf(!uumlaut)gbar:] Drive-B-Simulator.
+
+!item [Querverweis:]    (!link [Binding] [Bindings f(!uumlaut)r drvprotec])
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r drvprotec
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.l    #ptrdrv,-(sp) ; Offset 2
+move.w    #$131,-(sp)   ; Offset 0
+trap      #13           ; BIOS aufrufen
+addq.l    #6,sp         ; Stack korrigieren
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(305,L:prtdrv%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!endif
+

--- a/bios/bsim/dstate.ui
+++ b/bios/bsim/dstate.ui
@@ -1,0 +1,124 @@
+!iflang [english]
+
+!begin_node dstate
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Drive status(!ldouble) - Get RAM-disk details
+!item [Opcode:]
+306 (0x0132)
+!item [Syntax:]
+(!link [See 'Bindings for dstate'] [Bindings for dstate])
+!item [Description:]
+The (!nolink [BIOS]) routine dstate copies details of the RAM-disk into
+the buffer pointed to by (!I)pointer(!i). The structure is as follows:
+!begin_xlist !compressed [Description]
+!item [Offset]
+Description
+!item [~]
+~
+!item [0 (long)]
+Memory start address of the disk
+!item [4 (long)]
+Disk size
+!item [8 (short)]
+Sides
+!item [10 (short)]
+Tracks
+!item [12 (short)]
+Sectors
+!end_xlist
+
+!item [(!nolink [Return]) value:]
+The function returns 0 in DO on success, or -1 if there is no disk in memory.
+
+!item [Availability:] Drive-B-Simulator.
+
+!item [See also:]    (!link [Binding] [Bindings for dstate])
+
+(!ende_liste)
+
+
+!begin_node Bindings for dstate
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+pea       pointer(pc)   ; Offset 2
+move.w    #$132,-(sp)   ; Offset 0
+trap      #13           ; Call BIOS
+addq.l    #6,sp         ; Correct stack
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(306,L:pointer%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node dstate
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Drive status(!ldouble) - Get RAM-disk details.
+!item [Biosnummer:]
+306 (0x0132)
+!item [Deklaration:]
+Bindings f(!uumlaut)r dstate
+!item [Beschreibung:]
+Die Funktion ermittelt den Deskriptorfeld f(!uumlaut)r die RAM-Disk.
+Der (!I)pointer(!i) zeigt auf Deskriptorfeld.
+!begin_xlist !compressed [Beschreibung]
+!item [Offset]
+Beschreibung
+!item [~]
+~
+!item [0 (long)]
+Startadresse der Disk im Speicher
+!item [4 (long)]
+L(!aumlaut)nge der Disk
+!item [8 (short)]
+Seiten (der eingelesenen Disk)
+!item [10 (short)]
+Tracks
+!item [12 (short)]
+Sektoren
+!end_xlist
+
+!item [Ergebnis:]
+Die Funktion kann folgende R(!uumlaut)ckgabewerte liefern in D0:
+!begin_xlist !compressed [E_OK:]
+!item [E_OK:]
+OK
+!item [-1:]
+Keine Disk im Speicher
+!end_xlist
+
+!item [Verf(!uumlaut)gbar:] Drive-B-Simulator.
+
+!item [Querverweis:]    (!link [Binding] [Bindings f(!uumlaut)r dstate])
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r dstate
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+pea       pointer       ; Offset 2
+move.w    #$132,-(sp)   ; Offset 0
+trap      #13           ; BIOS aufrufen
+addq.l    #6,sp         ; Stack korrigieren
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(306,L:pointer%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!endif
+

--- a/bios/bsim/kill_disk.ui
+++ b/bios/bsim/kill_disk.ui
@@ -1,0 +1,95 @@
+!iflang [english]
+
+!begin_node kill_disk
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Kill disk(!ldouble) - Remove disk from memory
+!item [Opcode:]
+302 (0x012e)
+!item [Syntax:]
+(!link [See 'Bindings for kill_disk'] [Bindings for kill_disk])
+!item [Description:]
+The (!nolink [BIOS]) routine kill_disk removes the disk from memory.
+
+!item [(!nolink [Return]) value:]
+The function can return the following results in D0:
+!begin_xlist !compressed [E_OK:]
+!item [E_OK:]
+No error has arisen
+!item [-1:]
+Wrong magic value
+!end_xlist
+
+!item [Availability:] Drive-B-Simulator.
+
+!item [See also:]    (!link [Binding] [Bindings for kill_disk])
+
+(!ende_liste)
+
+
+!begin_node Bindings for kill_disk
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.l    #magic,-(sp)  ; Offset 2, magic:$87654321
+move.w    #$12E,-(sp)   ; Offset 0
+trap      #13           ; Call BIOS
+addq.l    #6,sp         ; Correct stack
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(302,L:magic%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node kill_disk
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Kill disk(!ldouble) - l(!oumlaut)scht Diskette.
+!item [Biosnummer:]
+302 (0x012e)
+!item [Deklaration:]
+Bindings f(!uumlaut)r kill_disk
+!item [Beschreibung:]
+Die Funktion l(!oumlaut)scht die Diskette aus dem Speicher.
+!item [Ergebnis:]
+Die Funktion kann folgende R(!uumlaut)ckgabewerte liefern in D0:
+!begin_xlist !compressed [E_OK:]
+!item [E_OK:]
+Disk ist gel(!oumlaut)scht
+!item [-1:]
+Falsches Magic
+!end_xlist
+
+!item [Verf(!uumlaut)gbar:] Drive-B-Simulator.
+
+!item [Querverweis:]    (!link [Binding] [Bindings f(!uumlaut)r kill_disk])
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r kill_disk
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.l    #magic,-(sp)  ; Offset 2, magic:$87654321
+move.w    #$12E,-(sp)   ; Offset 0
+trap      #13           ; BIOS aufrufen
+addq.l    #6,sp         ; Stack korrigieren
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(302,L:magic%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!endif
+

--- a/bios/bsim/load_disk.ui
+++ b/bios/bsim/load_disk.ui
@@ -1,0 +1,107 @@
+!iflang [english]
+
+!begin_node load_disk
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Load disk(!ldouble) - Load a disk into memory
+!item [Opcode:]
+301 (0x012d)
+!item [Syntax:]
+(!link [See 'Bindings for load_disk'] [Bindings for load_disk])
+!item [Description:]
+The (!nolink [BIOS]) routine loads the disk into memory.
+
+!item [(!nolink [Return]) value:]
+The function can return the following results in D0:
+!begin_xlist !compressed [E_OK:]
+!item [E_OK:]
+No error has arisen
+!item [-1:]
+Not enough memory
+!item [-2:]
+A disk is already in memory
+!item [-3:]
+Disk error
+!item [-4:]
+Wrong magic value
+!end_xlist
+
+!item [Availability:] Drive-B-Simulator.
+
+!item [See also:]    (!link [Binding] [Bindings for load_disk])
+
+(!ende_liste)
+
+
+!begin_node Bindings for load_disk
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.l    #magic,-(sp)  ; Offset 2, magic:$12345678
+move.w    #$12D,-(sp)   ; Offset 0
+trap      #13           ; Call BIOS
+addq.l    #6,sp         ; Correct stack
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(301,L:magic%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node load_disk
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Load disk(!ldouble) - l(!aumlaut)dt eine Diskette in den Speicher.
+!item [Biosnummer:]
+301 (0x012d)
+!item [Deklaration:]
+Bindings f(!uumlaut)r load_disk
+!item [Beschreibung:]
+Die Funktion l(!aumlaut)dt eine Diskette in den Speicher.
+!item [Ergebnis:]
+Die Funktion kann folgende R(!uumlaut)ckgabewerte liefern in D0:
+!begin_xlist !compressed [E_OK:]
+!item [E_OK:]
+OK
+!item [-1:]
+Zuwenig Speicher
+!item [-2:]
+Bereits eine Disk im Speicher
+!item [-3:]
+Disk Error
+!item [-4:]
+Falsches Magic
+!end_xlist
+
+!item [Verf(!uumlaut)gbar:] Drive-B-Simulator.
+
+!item [Querverweis:]    (!link [Binding] [Bindings f(!uumlaut)r load_disk])
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r load_disk
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.l    #magic,-(sp)  ; Offset 2, magic:$12345678
+move.w    #$12D,-(sp)   ; Offset 0
+trap      #13           ; BIOS aufrufen
+addq.l    #6,sp         ; Stack korrigieren
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(301,L:magic%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!endif
+

--- a/bios/bsim/save_disk.ui
+++ b/bios/bsim/save_disk.ui
@@ -1,0 +1,103 @@
+!iflang [english]
+
+!begin_node save_disk
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Save disk(!ldouble) - Save RAM-disk to disk
+!item [Opcode:]
+303 (0x012f)
+!item [Syntax:]
+(!link [See 'Bindings for save_disk'] [Bindings for save_disk])
+!item [Description:]
+The (!nolink [BIOS]) routine save_disk saves data from memory to the disk.
+
+!item [(!nolink [Return]) value:]
+The function can return the following results in D0:
+!begin_xlist !compressed [E_OK:]
+!item [E_OK:]
+No error has arisen
+!item [-1:]
+Wrong magic value
+!item [-2:]
+No disk in memory
+!item [-4:]
+Write error
+!end_xlist
+
+!item [Availability:] Drive-B-Simulator.
+
+!item [See also:]    (!link [Binding] [Bindings for save_disk])
+
+(!ende_liste)
+
+
+!begin_node Bindings for save_disk
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.l    #magic,-(sp)  ; Offset 2, magic:$ABCD0123
+move.w    #$12F,-(sp)   ; Offset 0
+trap      #13           ; Call BIOS
+addq.l    #6,sp         ; Correct stack
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(303,L:magic%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node save_disk
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Save disk(!ldouble) - schreibt Diskette.
+!item [Biosnummer:]
+303 (0x012f)
+!item [Deklaration:]
+Bindings f(!uumlaut)r save_disk
+!item [Beschreibung:]
+Die Funktion schreibt den Speicher auf die Diskette.
+!item [Ergebnis:]
+Die Funktion kann folgende R(!uumlaut)ckgabewerte liefern in D0:
+!begin_xlist !compressed [E_OK:]
+!item [E_OK:]
+Alles OK
+!item [-1:]
+Falsches Magic
+!item [-2:]
+Keine Disk im Speicher
+!item [-4:]
+Schreibfehler
+!end_xlist
+
+!item [Verf(!uumlaut)gbar:] Drive-B-Simulator.
+
+!item [Querverweis:]    (!link [Binding] [Bindings f(!uumlaut)r save_disk])
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r save_disk
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [Assembler:]
+!begin_verbatim
+move.l    #magic,-(sp)  ; Offset 2, magic:$ABCD0123
+move.w    #$12F,-(sp)   ; Offset 0
+trap      #13           ; BIOS aufrufen
+addq.l    #6,sp         ; Stack korrigieren
+!end_verbatim
+
+!item [GFA-Basic:]
+Fehler%=Bios(303,L:magic%)
+
+(!ende_liste)
+!end_node
+!end_node
+
+!endif
+


### PR DESCRIPTION
Adds description for all BIOS functions added by Drive-B-Simulator. As a result, all links from BIOS list are now working.

Drive-B-Simulator (binary) is available here: 
- TOS MAGAZIN 1992-03
- http://www.homecomputerworld.com/tos-mag92.html
- Disk 3/1992
- Pages 86-88

Works with Atari TOS. Crashes with EmuTOS