### PR TITLE
Add VIDIX XBIOS extension

### DIFF
--- a/xbios/structures/structures.u
+++ b/xbios/structures/structures.u
@@ -36,6 +36,13 @@
 !include xbios/structures/SCRTEXTUREMEMBLK.ui
 !include xbios/structures/VDO_MODE.ui
 !include xbios/structures/VDO_PARAM.ui
+!include xbios/structures/vidix_capability.ui
+!include xbios/structures/vidix_deinterlace.ui
+!include xbios/structures/vidix_dma.ui
+!include xbios/structures/vidix_fourcc.ui
+!include xbios/structures/vidix_grkey.ui
+!include xbios/structures/vidix_playback.ui
+!include xbios/structures/vidix_video_eq.ui
 !include xbios/structures/VPOS.ui
 
 !end_node

--- a/xbios/structures/vidix_capability.ui
+++ b/xbios/structures/vidix_capability.ui
@@ -1,0 +1,73 @@
+!iflang [english]
+
+!begin_node vidix_capability_t
+!begin_verbatim
+typedef struct vidix_capability_s
+{
+   char    name[64];    /* Driver name */
+   char    author[64];  /* Author name */
+#define TYPE_OUTPUT      0x00000000    /* Is a video playback device */
+#define TYPE_CAPTURE     0x00000001    /* Is a capture device */
+#define TYPE_CODEC       0x00000002    /* Device supports hw (de)coding */
+#define TYPE_FX          0x00000004    /* Is a video effects device */
+   int    type;         /* Device type, see below */
+   unsigned reserved0[4];
+   int    maxwidth;
+   int    maxheight;
+   int    minwidth;
+   int    minheight;
+   int    maxframerate; /* -1 if unlimited */
+#define FLAG_NONE        0x00000000 /* No flags defined */
+#define FLAG_DMA         0x00000001 /* Card can use DMA */
+#define FLAG_EQ_DMA      0x00000002 /* Card can use DMA only if src pitch == dest pitch */
+#define FLAG_UPSCALER    0x00000010 /* Card supports hw upscaling */
+#define FLAG_DOWNSCALER  0x00000020 /* Card supports hw downscaling */
+#define FLAG_SUBPIC      0x00001000 /* Card supports DVD subpictures */
+#define FLAG_EQUALIZER   0x00002000 /* Card supports equalizer */
+   unsigned flags;      /* Feature flags, see above */
+   unsigned short vendor_id;
+   unsigned short device_id;
+   unsigned reserved1[4];
+}vidix_capability_t;
+!end_verbatim
+
+See also: VIDIX XBIOS extension
+!end_node
+
+!else
+
+!begin_node vidix_capability_t
+!begin_verbatim
+typedef struct vidix_capability_s
+{
+   char    name[64];    /* Driver name */
+   char    author[64];  /* Author name */
+#define TYPE_OUTPUT      0x00000000    /* Is a video playback device */
+#define TYPE_CAPTURE     0x00000001    /* Is a capture device */
+#define TYPE_CODEC       0x00000002    /* Device supports hw (de)coding */
+#define TYPE_FX          0x00000004    /* Is a video effects device */
+   int    type;         /* Device type, see below */
+   unsigned reserved0[4];
+   int    maxwidth;
+   int    maxheight;
+   int    minwidth;
+   int    minheight;
+   int    maxframerate; /* -1 if unlimited */
+#define FLAG_NONE        0x00000000 /* No flags defined */
+#define FLAG_DMA         0x00000001 /* Card can use DMA */
+#define FLAG_EQ_DMA      0x00000002 /* Card can use DMA only if src pitch == dest pitch */
+#define FLAG_UPSCALER    0x00000010 /* Card supports hw upscaling */
+#define FLAG_DOWNSCALER  0x00000020 /* Card supports hw downscaling */
+#define FLAG_SUBPIC      0x00001000 /* Card supports DVD subpictures */
+#define FLAG_EQUALIZER   0x00002000 /* Card supports equalizer */
+   unsigned flags;      /* Feature flags, see above */
+   unsigned short vendor_id;
+   unsigned short device_id;
+   unsigned reserved1[4];
+}vidix_capability_t;
+!end_verbatim
+
+Querverweis: VIDIX-XBIOS-Erweiterung
+!end_node
+
+!endif

--- a/xbios/structures/vidix_deinterlace.ui
+++ b/xbios/structures/vidix_deinterlace.ui
@@ -1,0 +1,41 @@
+!iflang [english]
+
+!begin_node vidix_deinterlace_t
+!begin_verbatim
+typedef struct vidix_deinterlace_s
+{
+#define CFG_NON_INTERLACED        0x00000000 /* stream is not interlaced */
+#define CFG_INTERLACED            0x00000001 /* stream is interlaced */
+#define CFG_EVEN_ODD_INTERLACING  0x00000002 /* first frame contains even fields but second - odd */
+#define CFG_ODD_EVEN_INTERLACING  0x00000004 /* first frame contains odd fields but second - even */
+#define CFG_UNIQUE_INTERLACING    0x00000008 /* field deinterlace_pattern is valid */
+#define CFG_UNKNOWN_INTERLACING   0x0000000f /* unknown deinterlacing - use adaptive if it's possible */
+   unsigned    flags;               /* driver -> app */
+   unsigned    deinterlace_pattern; /* driver -> app: deinterlace pattern if flag CFG_UNIQUE_INTERLACING is set */
+}vidix_deinterlace_t;
+!end_verbatim
+
+See also: VIDIX XBIOS extension
+!end_node
+
+!else
+
+!begin_node vidix_deinterlace_t
+!begin_verbatim
+typedef struct vidix_deinterlace_s
+{
+#define CFG_NON_INTERLACED        0x00000000 /* stream is not interlaced */
+#define CFG_INTERLACED            0x00000001 /* stream is interlaced */
+#define CFG_EVEN_ODD_INTERLACING  0x00000002 /* first frame contains even fields but second - odd */
+#define CFG_ODD_EVEN_INTERLACING  0x00000004 /* first frame contains odd fields but second - even */
+#define CFG_UNIQUE_INTERLACING    0x00000008 /* field deinterlace_pattern is valid */
+#define CFG_UNKNOWN_INTERLACING   0x0000000f /* unknown deinterlacing - use adaptive if it's possible */
+   unsigned    flags;               /* driver -> app */
+   unsigned    deinterlace_pattern; /* driver -> app: deinterlace pattern if flag CFG_UNIQUE_INTERLACING is set */
+}vidix_deinterlace_t;
+!end_verbatim
+
+Querverweis: VIDIX-XBIOS-Erweiterung
+!end_node
+
+!endif

--- a/xbios/structures/vidix_dma.ui
+++ b/xbios/structures/vidix_dma.ui
@@ -1,0 +1,49 @@
+!iflang [english]
+
+!begin_node vidix_dma_t
+!begin_verbatim
+typedef struct vidix_dma_s
+{
+   void *src;               /* app -> driver: Virtual address of source */
+   unsigned dest_offset;    /* app -> driver: Destination offset within of video memory */
+   unsigned size;           /* app -> driver: Size of transaction */
+#define BM_DMA_NOSYNC      0
+#define BM_DMA_SYNC        1 /* wait previous dma transfer completion */
+#define BM_DMA_FIXED_BUFFS 2 /* app uses buffers witch are fixed in memory */
+#define BM_DMA_BLOCK       4 /* block until the transfer is complete */
+   unsigned flags;          /* app -> driver */
+   unsigned idx;            /* app -> driver: index of the src buffer */
+   unsigned src_incr;       /* app -> driver: if src_incr & dest_incr are */
+   unsigned dest_incr;      /*                different, else 0 */
+   void *internal[VID_PLAY_MAXFRAMES];    /* for internal use by driver */
+}vidix_dma_t;
+!end_verbatim
+
+See also: VIDIX XBIOS extension
+!end_node
+
+!else
+
+!begin_node vidix_dma_t
+!begin_verbatim
+typedef struct vidix_dma_s
+{
+   void *src;               /* app -> driver: Virtual address of source */
+   unsigned dest_offset;    /* app -> driver: Destination offset within of video memory */
+   unsigned size;           /* app -> driver: Size of transaction */
+#define BM_DMA_NOSYNC      0
+#define BM_DMA_SYNC        1 /* wait previous dma transfer completion */
+#define BM_DMA_FIXED_BUFFS 2 /* app uses buffers witch are fixed in memory */
+#define BM_DMA_BLOCK       4 /* block until the transfer is complete */
+   unsigned flags;          /* app -> driver */
+   unsigned idx;            /* app -> driver: index of the src buffer */
+   unsigned src_incr;       /* app -> driver: if src_incr & dest_incr are */
+   unsigned dest_incr;      /*                different, else 0 */
+   void *internal[VID_PLAY_MAXFRAMES];    /* for internal use by driver */
+}vidix_dma_t;
+!end_verbatim
+
+Querverweis: VIDIX-XBIOS-Erweiterung
+!end_node
+
+!endif

--- a/xbios/structures/vidix_fourcc.ui
+++ b/xbios/structures/vidix_fourcc.ui
@@ -1,0 +1,79 @@
+!iflang [english]
+
+!begin_node vidix_fourcc_t
+!begin_verbatim
+typedef struct vidix_fourcc_s
+{
+   unsigned fourcc; /* input: requested fourcc */
+   unsigned srcw;   /* input: hint: width of source */
+   unsigned srch;   /* input: hint: height of source */
+#define VID_DEPTH_NONE             0x0000
+#define VID_DEPTH_1BPP             0x0001
+#define VID_DEPTH_2BPP             0x0002
+#define VID_DEPTH_4BPP             0x0004
+#define VID_DEPTH_8BPP             0x0008
+#define VID_DEPTH_12BPP            0x0010
+#define VID_DEPTH_15BPP            0x0020
+#define VID_DEPTH_16BPP            0x0040
+#define VID_DEPTH_24BPP            0x0080
+#define VID_DEPTH_32BPP            0x0100
+   unsigned depth; /* output: screen depth for given fourcc */
+#define VID_CAP_NONE               0x0000
+#define VID_CAP_EXPAND             0x0001 /* if overlay can be bigger than source */
+#define VID_CAP_SHRINK             0x0002 /* if overlay can be smaller than source */
+#define VID_CAP_BLEND              0x0004 /* if overlay can be blended with framebuffer */
+#define VID_CAP_COLORKEY           0x0008 /* if overlay can be restricted to a colorkey */
+#define VID_CAP_ALPHAKEY           0x0010 /* if overlay can be restricted to an alpha channel */
+#define VID_CAP_COLORKEY_ISRANGE   0x0020 /* if the colorkey can be a range */
+#define VID_CAP_ALPHAKEY_ISRANGE   0x0040 /* if the alphakey can be a range */
+#define VID_CAP_COLORKEY_ISMAIN    0x0080 /* colorkey is checked against framebuffer */
+#define VID_CAP_COLORKEY_ISOVERLAY 0x0100 /* colorkey is checked against overlay */
+#define VID_CAP_ALPHAKEY_ISMAIN    0x0200 /* alphakey is checked against framebuffer */
+#define VID_CAP_ALPHAKEY_ISOVERLAY 0x0400 /* alphakey is checked against overlay */
+   unsigned flags; /* output: capability */
+}vidix_fourcc_t;
+!end_verbatim
+
+See also: VIDIX XBIOS extension
+!end_node
+
+!else
+
+!begin_node vidix_fourcc_t
+!begin_verbatim
+typedef struct vidix_fourcc_s
+{
+   unsigned fourcc; /* input: requested fourcc */
+   unsigned srcw;   /* input: hint: width of source */
+   unsigned srch;   /* input: hint: height of source */
+#define VID_DEPTH_NONE             0x0000
+#define VID_DEPTH_1BPP             0x0001
+#define VID_DEPTH_2BPP             0x0002
+#define VID_DEPTH_4BPP             0x0004
+#define VID_DEPTH_8BPP             0x0008
+#define VID_DEPTH_12BPP            0x0010
+#define VID_DEPTH_15BPP            0x0020
+#define VID_DEPTH_16BPP            0x0040
+#define VID_DEPTH_24BPP            0x0080
+#define VID_DEPTH_32BPP            0x0100
+   unsigned depth; /* output: screen depth for given fourcc */
+#define VID_CAP_NONE               0x0000
+#define VID_CAP_EXPAND             0x0001 /* if overlay can be bigger than source */
+#define VID_CAP_SHRINK             0x0002 /* if overlay can be smaller than source */
+#define VID_CAP_BLEND              0x0004 /* if overlay can be blended with framebuffer */
+#define VID_CAP_COLORKEY           0x0008 /* if overlay can be restricted to a colorkey */
+#define VID_CAP_ALPHAKEY           0x0010 /* if overlay can be restricted to an alpha channel */
+#define VID_CAP_COLORKEY_ISRANGE   0x0020 /* if the colorkey can be a range */
+#define VID_CAP_ALPHAKEY_ISRANGE   0x0040 /* if the alphakey can be a range */
+#define VID_CAP_COLORKEY_ISMAIN    0x0080 /* colorkey is checked against framebuffer */
+#define VID_CAP_COLORKEY_ISOVERLAY 0x0100 /* colorkey is checked against overlay */
+#define VID_CAP_ALPHAKEY_ISMAIN    0x0200 /* alphakey is checked against framebuffer */
+#define VID_CAP_ALPHAKEY_ISOVERLAY 0x0400 /* alphakey is checked against overlay */
+   unsigned flags; /* output: capability */
+}vidix_fourcc_t;
+!end_verbatim
+
+Querverweis: VIDIX-XBIOS-Erweiterung
+!end_node
+
+!endif

--- a/xbios/structures/vidix_grkey.ui
+++ b/xbios/structures/vidix_grkey.ui
@@ -1,0 +1,39 @@
+!iflang [english]
+
+!begin_node vidix_grkey_t
+!begin_verbatim
+typedef struct vidix_grkey_s
+{
+   vidix_ckey_t    ckey;      /* driver -> app: color key */
+   vidix_vkey_t    vkey;      /* driver -> app: video key */
+#define KEYS_PUT    0
+#define KEYS_AND    1
+#define KEYS_OR     2
+#define KEYS_XOR    3
+   unsigned    key_op;        /* driver -> app: keys operations */
+}vidix_grkey_t;
+!end_verbatim
+
+See also: VIDIX XBIOS extension
+!end_node
+
+!else
+
+!begin_node vidix_grkey_t
+!begin_verbatim
+typedef struct vidix_grkey_s
+{
+   vidix_ckey_t    ckey;      /* driver -> app: color key */
+   vidix_vkey_t    vkey;      /* driver -> app: video key */
+#define KEYS_PUT    0
+#define KEYS_AND    1
+#define KEYS_OR     2
+#define KEYS_XOR    3
+   unsigned    key_op;        /* driver -> app: keys operations */
+}vidix_grkey_t;
+!end_verbatim
+
+Querverweis: VIDIX-XBIOS-Erweiterung
+!end_node
+
+!endif

--- a/xbios/structures/vidix_playback.ui
+++ b/xbios/structures/vidix_playback.ui
@@ -1,0 +1,57 @@
+!iflang [english]
+
+!begin_node vidix_playback_t
+!begin_verbatim
+typedef struct vidix_playback_s
+{
+   unsigned fourcc;           /* app -> driver: movies's fourcc */
+   unsigned capability;       /* app -> driver: what capability to use */
+   unsigned blend_factor;     /* app -> driver: blending factor */
+   vidix_rect_t src;          /* app -> driver: original movie size */
+   vidix_rect_t dest;         /* app -> driver: destinition movie size. driver->app dest_pitch */
+#define VID_PLAY_INTERLEAVED_UV 0x00000001    /* driver -> app: interleaved UV planes */
+#define INTERLEAVING_UV         0x00001000    /* UVUVUVUVUV used by Matrox G200 */
+#define INTERLEAVING_VU         0x00001001    /* VUVUVUVUVU */
+   int        flags;
+   /* memory model */
+   unsigned frame_size;       /* driver -> app: destinition frame size */
+   unsigned num_frames;       /* app -> driver: after call: driver -> app */
+#define VID_PLAY_MAXFRAMES 64 /* reasonable limitation for decoding ahead */
+   unsigned offsets[VID_PLAY_MAXFRAMES];    /* driver -> app */
+   vidix_yuv_t    offset;     /* driver -> app: relative offsets within frame for yuv planes */
+   void    *dga_addr;         /* driver -> app: linear address */
+}vidix_playback_t;
+!end_verbatim
+
+See also: VIDIX XBIOS extension
+!end_node
+
+!else
+
+!begin_node vidix_playback_t
+!begin_verbatim
+typedef struct vidix_playback_s
+{
+   unsigned fourcc;           /* app -> driver: movies's fourcc */
+   unsigned capability;       /* app -> driver: what capability to use */
+   unsigned blend_factor;     /* app -> driver: blending factor */
+   vidix_rect_t src;          /* app -> driver: original movie size */
+   vidix_rect_t dest;         /* app -> driver: destinition movie size. driver->app dest_pitch */
+#define VID_PLAY_INTERLEAVED_UV 0x00000001    /* driver -> app: interleaved UV planes */
+#define INTERLEAVING_UV         0x00001000    /* UVUVUVUVUV used by Matrox G200 */
+#define INTERLEAVING_VU         0x00001001    /* VUVUVUVUVU */
+   int        flags;
+   /* memory model */
+   unsigned frame_size;       /* driver -> app: destinition frame size */
+   unsigned num_frames;       /* app -> driver: after call: driver -> app */
+#define VID_PLAY_MAXFRAMES 64 /* reasonable limitation for decoding ahead */
+   unsigned offsets[VID_PLAY_MAXFRAMES];    /* driver -> app */
+   vidix_yuv_t    offset;     /* driver -> app: relative offsets within frame for yuv planes */
+   void    *dga_addr;         /* driver -> app: linear address */
+}vidix_playback_t;
+!end_verbatim
+
+Querverweis: VIDIX-XBIOS-Erweiterung
+!end_node
+
+!endif

--- a/xbios/structures/vidix_video_eq.ui
+++ b/xbios/structures/vidix_video_eq.ui
@@ -1,0 +1,63 @@
+!iflang [english]
+
+!begin_node vidix_video_eq_t
+!begin_verbatim
+typedef struct vidix_video_eq_s
+{
+#define VEQ_CAP_NONE            0x00000000UL
+#define VEQ_CAP_BRIGHTNESS      0x00000001UL
+#define VEQ_CAP_CONTRAST        0x00000002UL
+#define VEQ_CAP_SATURATION      0x00000004UL
+#define VEQ_CAP_HUE             0x00000008UL
+#define VEQ_CAP_RGB_INTENSITY   0x00000010UL
+   int        cap;             /* should contain capability of equalizer */
+   /* end-user app can have presets like: cold-normal-hot picture and so on */
+   int        brightness;      /* -1000 : +1000 */
+   int        contrast;        /* -1000 : +1000 */
+   int        saturation;      /* -1000 : +1000 */
+   int        hue;             /* -1000 : +1000 */
+   int        red_intensity;   /* -1000 : +1000 */
+   int        green_intensity; /* -1000 : +1000 */
+   int        blue_intensity;  /* -1000 : +1000 */
+#define VEQ_FLG_ITU_R_BT_601    0x00000000 /* ITU-R BT.601 colour space (default) */
+#define VEQ_FLG_ITU_R_BT_709    0x00000001 /* ITU-R BT.709 colour space */
+#define VEQ_FLG_ITU_MASK        0x0000000f
+   int        flags;           /* currently specifies ITU YCrCb color space to use */
+}vidix_video_eq_t;
+!end_verbatim
+
+See also: VIDIX XBIOS extension
+!end_node
+
+!else
+
+!begin_node vidix_video_eq_t
+!begin_verbatim
+typedef struct vidix_video_eq_s
+{
+#define VEQ_CAP_NONE            0x00000000UL
+#define VEQ_CAP_BRIGHTNESS      0x00000001UL
+#define VEQ_CAP_CONTRAST        0x00000002UL
+#define VEQ_CAP_SATURATION      0x00000004UL
+#define VEQ_CAP_HUE             0x00000008UL
+#define VEQ_CAP_RGB_INTENSITY   0x00000010UL
+   int        cap;             /* should contain capability of equalizer */
+   /* end-user app can have presets like: cold-normal-hot picture and so on */
+   int        brightness;      /* -1000 : +1000 */
+   int        contrast;        /* -1000 : +1000 */
+   int        saturation;      /* -1000 : +1000 */
+   int        hue;             /* -1000 : +1000 */
+   int        red_intensity;   /* -1000 : +1000 */
+   int        green_intensity; /* -1000 : +1000 */
+   int        blue_intensity;  /* -1000 : +1000 */
+#define VEQ_FLG_ITU_R_BT_601    0x00000000 /* ITU-R BT.601 colour space (default) */
+#define VEQ_FLG_ITU_R_BT_709    0x00000001 /* ITU-R BT.709 colour space */
+#define VEQ_FLG_ITU_MASK        0x0000000f
+   int        flags;           /* currently specifies ITU YCrCb color space to use */
+}vidix_video_eq_t;
+!end_verbatim
+
+Querverweis: VIDIX-XBIOS-Erweiterung
+!end_node
+
+!endif

--- a/xbios/vidix/vdxconfigplayback.ui
+++ b/xbios/vidix/vdxconfigplayback.ui
@@ -1,0 +1,255 @@
+!iflang [english]
+
+
+!begin_node vdxConfigPlayback
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxConfigPlayback(!ldouble) - Prepare BES (BackEnd Scaler).
+
+!item [Opcode:]
+406 (0x0196)
+
+!item [Syntax:]
+int32_t vdxConfigPlayback ( vidix_playback_t *info ) ;
+
+!item [Description:]
+Driver should prepare BES on this call. 
+
+APP pass to driver the following (!I)info(!i):
+!begin_xlist !compressed [vidix_playback_t.blend_factor]
+!item [Field]
+Meaning
+!item [vidix_playback_t.fourcc]
+Contains fourcc of movie.
+!item [vidix_playback_t.capability]
+Currently contains a copy of vidix_capability_t.flags.
+!item [vidix_playback_t.blend_factor]
+Currently unused.
+!item [vidix_playback_t.src]
+x,y,w,h fields contain original movie size (in pixels) x and y often are nulls.
+!item [vidix_playback_t.src.pitch]
+y, u, v fields contain source pitches for each Y,U,V plane in bytes (For packed
+fourcc only Y value is used). They are hints for driver to use same destinition
+pitches as in source memory (to speed up memcpy process). Note: when source
+pitches are unknown or variable these field will be filled into 0.
+!item [vidix_playback_t.dest]
+x,y,w,h fields contains destination rectangle on the screen in pixels.
+!item [vidix_playback_t.num_frames]
+Maximal # of frames which can be used by APP. (Currently 10).
+!end_xlist
+
+Driver should fill following fields:
+!begin_xlist !compressed []
+!item [Field]
+Meaning
+!item [vidix_playback_t.num_frames]
+Real # of frames which will be used by driver. (Should be less or equal to app's num_frames).
+!item [vidix_playback_t.dest.pitch]
+y, u, v fields should contain alignment for each Y,U,V plane in bytes. (For
+packed fourcc only Y value is used).
+!item [vidix_playback_t.frame_size]
+Driver should tell to app which size of source frame (src.w and src.h) should
+use APP (according to pitches and offsets).
+!item [vidix_playback_t.offsets]
+Offsets from begin of BES memory for each frame.
+!item [vidix_playback_t.offset]
+y, u, v fields should contain offset for each Y,U,V plane within frame. (For
+packed fourcc only Y value is used).
+!item [vidix_playback_t.dga_addr]
+Address of BES memory.
+!end_xlist
+
+Also see this picture:
+!begin_verbatim
+    VIDEO MEMORY layout:
+     +-----------  It's begin of video memory     End of video memory--------------+
+     |                                                                             |
+     v                                                                             v
+     [      RGB memory                         |         YUV memory    |  UNDEF    ]
+                                               ^
+                                               |
+                                               +---- begin of BES memory         
+    BES MEMORY layout:
+     +-------- begin of BES memory
+     |
+     v
+     [ | |                      |       |       |
+       ^ ^                      ^       ^       ^
+       | |                      |       |       + BEGIN of second frame
+       | |                      |       + BEGIN of V plane
+       | |                      + BEGIN of U plane
+       | +------- BEGIN of Y plane
+       |
+       +--------- BEGIN of first frame
+!end_verbatim
+
+This means that in general case: (!nl)
+offset of frame != offset of BES (!nl)
+offset of Y plane != offset of first frame
+
+But often: (!nolink [vidix_playback_t]).offsets[0] = (!nolink [vidix_playback_t]).offset.y = 0;
+
+Formula: (For Y plane) copy source to:
+    (!nolink [vidix_playback_t]).dga_addr + (!nolink [vidix_playback_t]).offsets[i] + (!nolink [vidix_playback_t]).offset.y
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension][VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxConfigPlayback]) ~ vdxPlaybackCopyFrame ~
+vdxPlaybackFrameSelect ~ vdxQueryDMAStatus ~ vdxQueryFourcc
+
+(!ende_liste)
+
+!begin_node Bindings for vdxConfigPlayback
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxConfigPlayback ( vidix_playback_t *info );
+!item [Assembler:]
+!begin_verbatim
+pea       info         ; Offset 2
+move.w    #406,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxConfigPlayback
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxConfigPlayback(!ldouble) - Prepare BES (BackEnd Scaler).
+
+!item [Xbiosnummer:]
+406 (0x0196)
+
+!item [Deklaration:]
+int32_t vdxConfigPlayback ( vidix_playback_t *info );
+
+!item [Beschreibung:]
+Driver should prepare BES on this call. 
+
+APP pass to driver the following (!I)info(!i):
+!begin_xlist !compressed [vidix_playback_t.blend_factor]
+!item [Field]
+Meaning
+!item [vidix_playback_t.fourcc]
+Contains fourcc of movie.
+!item [vidix_playback_t.capability]
+Currently contains a copy of vidix_capability_t.flags.
+!item [vidix_playback_t.blend_factor]
+Currently unused.
+!item [vidix_playback_t.src]
+x,y,w,h fields contain original movie size (in pixels) x and y often are nulls.
+!item [vidix_playback_t.src.pitch]
+y, u, v fields contain source pitches for each Y,U,V plane in bytes (For packed
+fourcc only Y value is used). They are hints for driver to use same destinition
+pitches as in source memory (to speed up memcpy process). Note: when source
+pitches are unknown or variable these field will be filled into 0.
+!item [vidix_playback_t.dest]
+x,y,w,h fields contains destination rectangle on the screen in pixels.
+!item [vidix_playback_t.num_frames]
+Maximal # of frames which can be used by APP. (Currently 10).
+!end_xlist
+
+Driver should fill following fields:
+!begin_xlist !compressed []
+!item [Field]
+Meaning
+!item [vidix_playback_t.num_frames]
+Real # of frames which will be used by driver. (Should be less or equal to app's num_frames).
+!item [vidix_playback_t.dest.pitch]
+y, u, v fields should contain alignment for each Y,U,V plane in bytes. (For
+packed fourcc only Y value is used).
+!item [vidix_playback_t.frame_size]
+Driver should tell to app which size of source frame (src.w and src.h) should
+use APP (according to pitches and offsets).
+!item [vidix_playback_t.offsets]
+Offsets from begin of BES memory for each frame.
+!item [vidix_playback_t.offset]
+y, u, v fields should contain offset for each Y,U,V plane within frame. (For
+packed fourcc only Y value is used).
+!item [vidix_playback_t.dga_addr]
+Address of BES memory.
+!end_xlist
+
+Also see this picture:
+!begin_verbatim
+    VIDEO MEMORY layout:
+     +-----------  It's begin of video memory     End of video memory--------------+
+     |                                                                             |
+     v                                                                             v
+     [      RGB memory                         |         YUV memory    |  UNDEF    ]
+                                               ^
+                                               |
+                                               +---- begin of BES memory         
+    BES MEMORY layout:
+     +-------- begin of BES memory
+     |
+     v
+     [ | |                      |       |       |
+       ^ ^                      ^       ^       ^
+       | |                      |       |       + BEGIN of second frame
+       | |                      |       + BEGIN of V plane
+       | |                      + BEGIN of U plane
+       | +------- BEGIN of Y plane
+       |
+       +--------- BEGIN of first frame
+!end_verbatim
+
+This means that in general case: (!nl)
+offset of frame != offset of BES (!nl)
+offset of Y plane != offset of first frame
+
+But often: (!nolink [vidix_playback_t]).offsets[0] = (!nolink [vidix_playback_t]).offset.y = 0;
+
+Formula: (For Y plane) copy source to:
+    (!nolink [vidix_playback_t]).dga_addr + (!nolink [vidix_playback_t]).offsets[i] + (!nolink [vidix_playback_t]).offset.y
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung][VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxConfigPlayback]) ~ vdxPlaybackCopyFrame ~
+vdxPlaybackFrameSelect ~ vdxQueryDMAStatus ~ vdxQueryFourcc
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxConfigPlayback
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxConfigPlayback ( vidix_playback_t *info );
+!item [Assembler:]
+!begin_verbatim
+pea       info         ; Offset 2
+move.w    #406,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxconfigplayback.ui
+++ b/xbios/vidix/vdxconfigplayback.ui
@@ -100,7 +100,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension][VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxConfigPlayback]) ~ vdxPlaybackCopyFrame ~
@@ -227,7 +227,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung][VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxConfigPlayback]) ~ vdxPlaybackCopyFrame ~

--- a/xbios/vidix/vdxdestroy.ui
+++ b/xbios/vidix/vdxdestroy.ui
@@ -1,0 +1,101 @@
+!iflang [english]
+
+
+!begin_node vdxDestroy
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxDestroy(!ldouble) - Quit driver.
+
+!item [Opcode:]
+403 (0x0193)
+
+!item [Syntax:]
+void vdxDestroy ( void ) ;
+
+!item [Description:]
+Quit the VIDIX driver.
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Nothing.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension][VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxDestroy]) ~ vdxInit
+
+(!ende_liste)
+
+!begin_node Bindings for vdxDestroy
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+void vdxDestroy ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #403,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #2,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxDestroy
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxDestroy(!ldouble) - Destroy driver.
+
+!item [Xbiosnummer:]
+403 (0x0193)
+
+!item [Deklaration:]
+void vdxDestroy ( void );
+
+!item [Beschreibung:]
+Quit the VIDIX driver.
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Nothing.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung][VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxDestroy]) ~ vdxInit
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxDestroy
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+void vdxDestroy ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #403,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #2,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxdestroy.ui
+++ b/xbios/vidix/vdxdestroy.ui
@@ -25,7 +25,7 @@ Nothing.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension][VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxDestroy]) ~ vdxInit
@@ -75,7 +75,7 @@ Nothing.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung][VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxDestroy]) ~ vdxInit

--- a/xbios/vidix/vdxgetcapability.ui
+++ b/xbios/vidix/vdxgetcapability.ui
@@ -23,7 +23,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension][VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxGetCapability]) ~ vdxGetVersion ~ vdxProbe
@@ -72,7 +72,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung][VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxGetCapability]) ~ vdxGetVersion ~ vdxProbe

--- a/xbios/vidix/vdxgetcapability.ui
+++ b/xbios/vidix/vdxgetcapability.ui
@@ -1,0 +1,99 @@
+!iflang [english]
+
+
+!begin_node vdxGetCapability
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxGetCapability(!ldouble) - Get capability.
+
+!item [Opcode:]
+404 (0x0194)
+
+!item [Syntax:]
+int32_t vdxGetCapability ( vidix_capability_t *to ) ;
+
+!item [Description:]
+Driver should return capability with filled vidix_capability_t.type field.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension][VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxGetCapability]) ~ vdxGetVersion ~ vdxProbe
+
+(!ende_liste)
+
+!begin_node Bindings for vdxGetCapability
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxGetCapability ( vidix_capability_t *to );
+!item [Assembler:]
+!begin_verbatim
+pea       to           ; Offset 2
+move.w    #404,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxGetCapability
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxGetCapability(!ldouble) - Get capability.
+
+!item [Xbiosnummer:]
+404 (0x0194)
+
+!item [Deklaration:]
+int32_t vdxGetCapability ( vidix_capability_t *to );
+
+!item [Beschreibung:]
+Driver should return capability with filled vidix_capability_t.type field.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung][VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxGetCapability]) ~ vdxGetVersion ~ vdxProbe
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxGetCapability
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxGetCapability ( vidix_capability_t *to );
+!item [Assembler:]
+!begin_verbatim
+pea       to           ; Offset 2
+move.w    #404,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxgetgrkeys.ui
+++ b/xbios/vidix/vdxgetgrkeys.ui
@@ -1,0 +1,105 @@
+!iflang [english]
+
+
+!begin_node vdxGetGrKeys
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxGetGrKeys(!ldouble) - Get graphic keys.
+
+!item [Opcode:]
+410 (0x019a)
+
+!item [Syntax:]
+int32_t vdxGetGrKeys ( vidix_grkey_t *grkey ) ;
+
+!item [Description:]
+This interface should be tuned but introduced for overlapped playback and video
+effects (TYPE_FX).
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxGetGrKeys]) ~ vdxSetGrKeys
+
+(!ende_liste)
+
+!begin_node Bindings for vdxGetGrKeys
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxGetGrKeys ( vidix_grkey_t *grkey );
+!item [Assembler:]
+!begin_verbatim
+pea       grkey        ; Offset 2
+move.w    #410,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxGetGrKeys
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxGetGrKeys(!ldouble) - Get graphic keys.
+
+!item [Xbiosnummer:]
+410 (0x019a)
+
+!item [Deklaration:]
+int32_t vdxGetGrKeys ( vidix_grkey_t *grkey );
+
+!item [Beschreibung:]
+This interface should be tuned but introduced for overlapped playback and video
+effects (TYPE_FX).
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxGetGrKeys]) ~ vdxSetGrKeys
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxGetGrKeys
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxGetGrKeys ( vidix_grkey_t *grkey );
+!item [Assembler:]
+!begin_verbatim
+pea       grkey        ; Offset 2
+move.w    #410,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxgetgrkeys.ui
+++ b/xbios/vidix/vdxgetgrkeys.ui
@@ -26,7 +26,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxGetGrKeys]) ~ vdxSetGrKeys
@@ -78,7 +78,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxGetGrKeys]) ~ vdxSetGrKeys

--- a/xbios/vidix/vdxgetversion.ui
+++ b/xbios/vidix/vdxgetversion.ui
@@ -23,7 +23,7 @@ Version.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxGetVersion]) ~ vdxGetCapability ~ vdxProbe
@@ -71,7 +71,7 @@ Version.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxGetVersion]) ~ vdxGetCapability ~ vdxProbe

--- a/xbios/vidix/vdxgetversion.ui
+++ b/xbios/vidix/vdxgetversion.ui
@@ -1,0 +1,97 @@
+!iflang [english]
+
+
+!begin_node vdxGetVersion
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxGetVersion(!ldouble) - Get version.
+
+!item [Opcode:]
+400 (0x0190)
+
+!item [Syntax:]
+unsigned vdxGetVersion ( void ) ;
+
+!item [Description:]
+Get the version.
+
+!item [(!nolink [Return]) value:]
+Version.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxGetVersion]) ~ vdxGetCapability ~ vdxProbe
+
+(!ende_liste)
+
+!begin_node Bindings for vdxGetVersion
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+unsigned vdxGetVersion ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #400,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #2,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxGetVersion
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Get Version(!ldouble) - Get version.
+
+!item [Xbiosnummer:]
+400 (0x0190)
+
+!item [Deklaration:]
+unsigned vdxGetVersion ( void );
+
+!item [Beschreibung:]
+Get the version.
+
+!item [Ergebnis:]
+Version.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxGetVersion]) ~ vdxGetCapability ~ vdxProbe
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxGetVersion
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+unsigned vdxGetVersion ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #400,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #2,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxinit.ui
+++ b/xbios/vidix/vdxinit.ui
@@ -1,0 +1,101 @@
+!iflang [english]
+
+
+!begin_node vdxInit
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxInit(!ldouble) - Initialize driver.
+
+!item [Opcode:]
+402 (0x0192)
+
+!item [Syntax:]
+int32_t vdxInit ( void ) ;
+
+!item [Description:]
+Initialize the VIDIX driver.
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxInit]) ~ vdxDestroy
+
+(!ende_liste)
+
+!begin_node Bindings for vdxInit
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxInit ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #402,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #2,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxInit
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxInit(!ldouble) - Initialize driver.
+
+!item [Xbiosnummer:]
+402 (0x0192)
+
+!item [Deklaration:]
+int32_t vdxInit ( void );
+
+!item [Beschreibung:]
+Initialize the VIDIX driver.
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxInit]) ~ vdxDestroy
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxInit
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxInit ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #402,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #2,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxinit.ui
+++ b/xbios/vidix/vdxinit.ui
@@ -25,7 +25,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxInit]) ~ vdxDestroy
@@ -75,7 +75,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxInit]) ~ vdxDestroy

--- a/xbios/vidix/vdxplaybackcopyframe.ui
+++ b/xbios/vidix/vdxplaybackcopyframe.ui
@@ -1,0 +1,105 @@
+!iflang [english]
+
+
+!begin_node vdxPlaybackCopyFrame
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxPlaybackCopyFrame(!ldouble) - Copy frame with DMA.
+
+!item [Opcode:]
+416 (0x01a0)
+
+!item [Syntax:]
+int32_t vdxPlaybackCopyFrame ( vidix_dma_t *dmai ) ;
+
+!item [Description:]
+Function for copy frame with the DMA.
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0 else EINVAL, ERANGE, ENOMEM, E2BIG or ENOSYS.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension][VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxPlaybackCopyFrame]) ~ vdxConfigPlayback ~
+vdxPlaybackFrameSelect ~ vdxQueryDMAStatus ~ vdxQueryFourcc
+
+(!ende_liste)
+
+!begin_node Bindings for vdxPlaybackCopyFrame
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackCopyFrame ( vidix_dma_t *dmai );
+!item [Assembler:]
+!begin_verbatim
+pea       dma          ; Offset 2
+move.w    #416,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxPlaybackCopyFrame
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxPlaybackCopyFrame(!ldouble) - Copy frame with DMA.
+
+!item [Xbiosnummer:]
+416 (0x01a0)
+
+!item [Deklaration:]
+int32_t vdxPlaybackCopyFrame ( vidix_dma_t *dmai );
+
+!item [Beschreibung:]
+Function for copy frame with the DMA.
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Driver should return 0 else EINVAL, ERANGE, ENOMEM, E2BIG or ENOSYS.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackCopyFrame]) ~ vdxConfigPlayback ~
+vdxPlaybackFrameSelect ~ vdxQueryDMAStatus ~ vdxQueryFourcc
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxPlaybackCopyFrame
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackCopyFrame ( vidix_dma_t *dmai );
+!item [Assembler:]
+!begin_verbatim
+pea       dmai         ; Offset 2
+move.w    #416,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxplaybackcopyframe.ui
+++ b/xbios/vidix/vdxplaybackcopyframe.ui
@@ -25,7 +25,7 @@ Driver should return 0 else EINVAL, ERANGE, ENOMEM, E2BIG or ENOSYS.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension][VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxPlaybackCopyFrame]) ~ vdxConfigPlayback ~
@@ -77,7 +77,7 @@ Driver should return 0 else EINVAL, ERANGE, ENOMEM, E2BIG or ENOSYS.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackCopyFrame]) ~ vdxConfigPlayback ~

--- a/xbios/vidix/vdxplaybackframeselect.ui
+++ b/xbios/vidix/vdxplaybackframeselect.ui
@@ -26,7 +26,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxPlaybackFrameSelect]) ~ vdxConfigPlayback ~
@@ -79,7 +79,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackFrameSelect]) ~ vdxConfigPlayback ~

--- a/xbios/vidix/vdxplaybackframeselect.ui
+++ b/xbios/vidix/vdxplaybackframeselect.ui
@@ -1,0 +1,107 @@
+!iflang [english]
+
+
+!begin_node vdxPlaybackFrameSelect
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxPlaybackFrameSelect(!ldouble) - Prepare frame.
+
+!item [Opcode:]
+409 (0x0199)
+
+!item [Syntax:]
+int32_t vdxPlaybackFrameSelect ( uint32_t frame ) ;
+
+!item [Description:]
+Driver should prepare and activate corresponded frame. This function is used only
+for double and triple buffering and never used for single buffering playback.
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxPlaybackFrameSelect]) ~ vdxConfigPlayback ~
+vdxPlaybackCopyFrame ~ vdxQueryDMAStatus ~ vdxQueryFourcc
+
+(!ende_liste)
+
+!begin_node Bindings for vdxPlaybackFrameSelect
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackFrameSelect ( uint32_t frame );
+!item [Assembler:]
+!begin_verbatim
+move.l    frame,-(sp)  ; Offset 2
+move.w    #409,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxPlaybackFrameSelect
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxPlaybackFrameSelect(!ldouble) - Prepare frame.
+
+!item [Xbiosnummer:]
+409 (0x0199)
+
+!item [Deklaration:]
+int32_t vdxPlaybackFrameSelect ( uint32_t frame );
+
+!item [Beschreibung:]
+Driver should prepare and activate corresponded frame. This function is used only
+for double and triple buffering and never used for single buffering playback.
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackFrameSelect]) ~ vdxConfigPlayback ~
+vdxPlaybackCopyFrame ~ vdxQueryDMAStatus ~ vdxQueryFourcc
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxPlaybackFrameSelect
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackFrameSelect ( uint32_t frame );
+!item [Assembler:]
+!begin_verbatim
+move.l    frame,-(sp)  ; Offset 2
+move.w    #409,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxplaybackgetdeint.ui
+++ b/xbios/vidix/vdxplaybackgetdeint.ui
@@ -1,0 +1,103 @@
+!iflang [english]
+
+
+!begin_node vdxPlaybackGetDeint
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxPlaybackGetDeint(!ldouble) - Get interlacing.
+
+!item [Opcode:]
+414 (0x019e)
+
+!item [Syntax:]
+int32_t vdxPlaybackGetDeint ( vidix_deinterlace_t *info ) ;
+
+!item [Description:]
+Function for get interlacing.
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxPlaybackGetDeint]) ~ vdxPlaybackSetDeint
+
+(!ende_liste)
+
+!begin_node Bindings for vdxPlaybackGetDeint
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackGetDeint ( vidix_deinterlace_t *info );
+!item [Assembler:]
+!begin_verbatim
+pea       info         ; Offset 2
+move.w    #414,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxPlaybackGetDeint
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxPlaybackGetDeint(!ldouble) - Get interlacing.
+
+!item [Xbiosnummer:]
+414 (0x019e)
+
+!item [Deklaration:]
+int32_t vdxPlaybackGetDeint ( vidix_deinterlace_t *info );
+
+!item [Beschreibung:]
+Function for get interlacing.
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackGetDeint]) ~ vdxPlaybackSetDeint
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxPlaybackGetDeint
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackGetDeint ( vidix_deinterlace_t *info );
+!item [Assembler:]
+!begin_verbatim
+pea       info         ; Offset 2
+move.w    #414,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxplaybackgetdeint.ui
+++ b/xbios/vidix/vdxplaybackgetdeint.ui
@@ -25,7 +25,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxPlaybackGetDeint]) ~ vdxPlaybackSetDeint
@@ -76,7 +76,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackGetDeint]) ~ vdxPlaybackSetDeint

--- a/xbios/vidix/vdxplaybackgeteq.ui
+++ b/xbios/vidix/vdxplaybackgeteq.ui
@@ -1,0 +1,103 @@
+!iflang [english]
+
+
+!begin_node vdxPlaybackGetEq
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxPlaybackGetEq(!ldouble) - Get color correction.
+
+!item [Opcode:]
+412 (0x019c)
+
+!item [Syntax:]
+int32_t vdxPlaybackGetEq ( vidix_video_eq_t *eq ) ;
+
+!item [Description:]
+Function for get color correction.
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxPlaybackGetEq]) ~ vdxPlaybackSetEq
+
+(!ende_liste)
+
+!begin_node Bindings for vdxPlaybackGetEq
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackGetEq ( vidix_video_eq_t *eq );
+!item [Assembler:]
+!begin_verbatim
+pea       eq           ; Offset 2
+move.w    #412,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxPlaybackGetEq
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxPlaybackGetEq(!ldouble) - Get color correction.
+
+!item [Xbiosnummer:]
+412 (0x019c)
+
+!item [Deklaration:]
+int32_t vdxPlaybackGetEq ( vidix_video_eq_t *eq );
+
+!item [Beschreibung:]
+Function for get color correction.
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackGetEq]) ~ vdxPlaybackSetEq
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxPlaybackGetEq
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackGetEq ( vidix_video_eq_t *eq );
+!item [Assembler:]
+!begin_verbatim
+pea       eq           ; Offset 2
+move.w    #412,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxplaybackgeteq.ui
+++ b/xbios/vidix/vdxplaybackgeteq.ui
@@ -25,7 +25,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxPlaybackGetEq]) ~ vdxPlaybackSetEq
@@ -76,7 +76,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackGetEq]) ~ vdxPlaybackSetEq

--- a/xbios/vidix/vdxplaybackoff.ui
+++ b/xbios/vidix/vdxplaybackoff.ui
@@ -23,7 +23,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension][VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxPlaybackOff]) ~ vdxPlaybackOn
@@ -71,7 +71,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackOff]) ~ vdxPlaybackOn

--- a/xbios/vidix/vdxplaybackoff.ui
+++ b/xbios/vidix/vdxplaybackoff.ui
@@ -1,0 +1,97 @@
+!iflang [english]
+
+
+!begin_node vdxPlaybackOff
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxPlaybackOff(!ldouble) - Deactivate BES.
+
+!item [Opcode:]
+408 (0x0198)
+
+!item [Syntax:]
+int32_t vdxPlaybackOff ( void ) ;
+
+!item [Description:]
+Driver should deactivate BES on this call.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension][VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxPlaybackOff]) ~ vdxPlaybackOn
+
+(!ende_liste)
+
+!begin_node Bindings for vdxPlaybackOff
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackOff ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #408,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #2,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxPlaybackOff
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxPlaybackOff(!ldouble) - Deactivate BES.
+
+!item [Xbiosnummer:]
+408 (0x0198)
+
+!item [Deklaration:]
+int32_t vdxPlaybackOff ( void );
+
+!item [Beschreibung:]
+Driver should deactivate BES on this call.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackOff]) ~ vdxPlaybackOn
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxPlaybackOff
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackOff ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #408,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #2,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxplaybackon.ui
+++ b/xbios/vidix/vdxplaybackon.ui
@@ -23,7 +23,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxPlaybackOn]) ~ vdxPlaybackOff
@@ -71,7 +71,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackOn]) ~ vdxPlaybackOff

--- a/xbios/vidix/vdxplaybackon.ui
+++ b/xbios/vidix/vdxplaybackon.ui
@@ -1,0 +1,97 @@
+!iflang [english]
+
+
+!begin_node vdxPlaybackOn
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxPlaybackOn(!ldouble) - Activate BES.
+
+!item [Opcode:]
+407 (0x0197)
+
+!item [Syntax:]
+int32_t vdxPlaybackOn ( void ) ;
+
+!item [Description:]
+Driver should activate BES on this call.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxPlaybackOn]) ~ vdxPlaybackOff
+
+(!ende_liste)
+
+!begin_node Bindings for vdxPlaybackOn
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackOn ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #407,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #2,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxPlaybackOn
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxPlaybackOn(!ldouble) - Activate BES.
+
+!item [Xbiosnummer:]
+407 (0x0197)
+
+!item [Deklaration:]
+int32_t vdxPlaybackOn ( void );
+
+!item [Beschreibung:]
+Driver should activate BES on this call.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackOn]) ~ vdxPlaybackOff
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxPlaybackOn
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackOn ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #407,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #2,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxplaybacksetdeint.ui
+++ b/xbios/vidix/vdxplaybacksetdeint.ui
@@ -1,0 +1,103 @@
+!iflang [english]
+
+
+!begin_node vdxPlaybackSetDeint
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxPlaybackSetDeint(!ldouble) - Set interlacing.
+
+!item [Opcode:]
+415 (0x019f)
+
+!item [Syntax:]
+int32_t vdxPlaybackSetDeint ( vidix_deinterlace_t *info ) ;
+
+!item [Description:]
+Function for set interlacing.
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxPlaybackSetDeint]) ~ vdxPlaybackGetDeint
+
+(!ende_liste)
+
+!begin_node Bindings for vdxPlaybackSetDeint
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackSetDeint ( vidix_deinterlace_t *info );
+!item [Assembler:]
+!begin_verbatim
+pea       info         ; Offset 2
+move.w    #415,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxPlaybackSetDeint
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxPlaybackSetDeint(!ldouble) - Set interlacing.
+
+!item [Xbiosnummer:]
+415 (0x019f)
+
+!item [Deklaration:]
+int32_t vdxPlaybackSetDeint ( vidix_deinterlace_t *info );
+
+!item [Beschreibung:]
+Function for set interlacing.
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackSetDeint]) ~ vdxPlaybackGetDeint
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxPlaybackSetDeint
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackSetDeint ( vidix_deinterlace_t *info );
+!item [Assembler:]
+!begin_verbatim
+pea       info         ; Offset 2
+move.w    #415,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxplaybacksetdeint.ui
+++ b/xbios/vidix/vdxplaybacksetdeint.ui
@@ -25,7 +25,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxPlaybackSetDeint]) ~ vdxPlaybackGetDeint
@@ -76,7 +76,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackSetDeint]) ~ vdxPlaybackGetDeint

--- a/xbios/vidix/vdxplaybackseteq.ui
+++ b/xbios/vidix/vdxplaybackseteq.ui
@@ -25,7 +25,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxPlaybackSetEq]) ~ vdxPlaybackGetEq
@@ -76,7 +76,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackSetEq]) vdxPlaybackGetEq

--- a/xbios/vidix/vdxplaybackseteq.ui
+++ b/xbios/vidix/vdxplaybackseteq.ui
@@ -1,0 +1,103 @@
+!iflang [english]
+
+
+!begin_node vdxPlaybackSetEq
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxPlaybackSetEq(!ldouble) - Set color correction.
+
+!item [Opcode:]
+413 (0x019d)
+
+!item [Syntax:]
+int32_t vdxPlaybackSetEq ( vidix_video_eq_t *eq ) ;
+
+!item [Description:]
+Function for set color correction.
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxPlaybackSetEq]) ~ vdxPlaybackGetEq
+
+(!ende_liste)
+
+!begin_node Bindings for vdxPlaybackSetEq
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackSetEq ( vidix_video_eq_t *eq );
+!item [Assembler:]
+!begin_verbatim
+pea       eq           ; Offset 2
+move.w    #413,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxPlaybackSetEq
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxPlaybackSetEq(!ldouble) - Set color correction.
+
+!item [Xbiosnummer:]
+413 (0x019d)
+
+!item [Deklaration:]
+int32_t vdxPlaybackSetEq ( vidix_video_eq_t *eq );
+
+!item [Beschreibung:]
+Function for set color correction.
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxPlaybackSetEq]) vdxPlaybackGetEq
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxPlaybackSetEq
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxPlaybackSetEq ( vidix_video_eq_t *eq );
+!item [Assembler:]
+!begin_verbatim
+pea       eq           ; Offset 2
+move.w    #413,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxprobe.ui
+++ b/xbios/vidix/vdxprobe.ui
@@ -24,7 +24,7 @@ Driver should return 0 if it can handle something else ENXIO.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxProbe]) ~ vdxGetCapability ~ vdxGetVersion
@@ -75,7 +75,7 @@ Driver should return 0 if it can handle something else ENXIO.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxProbe]) ~ vdxGetCapability ~ vdxGetVersion

--- a/xbios/vidix/vdxprobe.ui
+++ b/xbios/vidix/vdxprobe.ui
@@ -1,0 +1,103 @@
+!iflang [english]
+
+
+!begin_node vdxProbe
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxProbe(!ldouble) - Probe the board.
+
+!item [Opcode:]
+401 (0x0191)
+
+!item [Syntax:]
+int32_t vdxProbe ( int32_t verbose, int32_t force ) ;
+
+!item [Description:]
+Probe the board. (!I)verbose(!i) and (!I)force(!i) are unused for the Atari
+driver.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0 if it can handle something else ENXIO.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxProbe]) ~ vdxGetCapability ~ vdxGetVersion
+
+(!ende_liste)
+
+!begin_node Bindings for vdxProbe
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxProbe ( int32_t verbose, int32_t force );
+!item [Assembler:]
+!begin_verbatim
+move.l    force,-(sp)  ; Offset 6
+move.l    verbose,-(sp); Offset 2
+move.w    #401,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+lea       10(sp),sp    ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxProbe
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxProbe(!ldouble) - Probe the board.
+
+!item [Xbiosnummer:]
+401 (0x0191)
+
+!item [Deklaration:]
+int32_t vdxProbe ( int32_t verbose, int32_t force );
+
+!item [Beschreibung:]
+Probe the board. (!I)verbose(!i) and (!I)force(!i) are unused for the Atari
+driver.
+
+!item [Ergebnis:]
+Driver should return 0 if it can handle something else ENXIO.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxProbe]) ~ vdxGetCapability ~ vdxGetVersion
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxProbe
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxProbe ( int32_t verbose, int32_t force );
+!item [Assembler:]
+!begin_verbatim
+move.l    force,-(sp)  ; Offset 6
+move.l    verbose,-(sp); Offset 2
+move.w    #401,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+lea       10(sp),sp    ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxquerydmastatus.ui
+++ b/xbios/vidix/vdxquerydmastatus.ui
@@ -1,0 +1,103 @@
+!iflang [english]
+
+
+!begin_node vdxQueryDMAStatus
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxQueryDMAStatus(!ldouble) - Get DMA status.
+
+!item [Opcode:]
+417 (0x01a1)
+
+!item [Syntax:]
+int32_t vdxQueryDMAStatus ( void ) ;
+
+!item [Description:]
+Function for get the status of the DMA after a vdxPlaybackCopyFrame().
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0 or 1 if busy, else ENOSYS.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxQueryDMAStatus]) ~ vdxConfigPlayback ~ vdxPlaybackCopyFrame ~
+vdxPlaybackFrameSelect ~ vdxQueryFourcc
+
+(!ende_liste)
+
+!begin_node Bindings for vdxQueryDMAStatus
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxQueryDMAStatus ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #417,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #2,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxQueryDMAStatus
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxQueryDMAStatus(!ldouble) - Get DMA status.
+
+!item [Xbiosnummer:]
+417 (0x01a1)
+
+!item [Deklaration:]
+int32_t vdxQueryDMAStatus ( void );
+
+!item [Beschreibung:]
+Function for get the status of the DMA after a vdxPlaybackCopyFrame().
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Driver should return 0 or 1 if busy, else ENOSYS.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxQueryDMAStatus]) ~ vdxConfigPlayback ~ vdxPlaybackCopyFrame ~
+vdxPlaybackFrameSelect ~ vdxQueryFourcc
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxQueryDMAStatus
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxQueryDMAStatus ( void );
+!item [Assembler:]
+!begin_verbatim
+move.w    #417,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #2,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxquerydmastatus.ui
+++ b/xbios/vidix/vdxquerydmastatus.ui
@@ -25,7 +25,7 @@ Driver should return 0 or 1 if busy, else ENOSYS.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxQueryDMAStatus]) ~ vdxConfigPlayback ~ vdxPlaybackCopyFrame ~
@@ -76,7 +76,7 @@ Driver should return 0 or 1 if busy, else ENOSYS.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxQueryDMAStatus]) ~ vdxConfigPlayback ~ vdxPlaybackCopyFrame ~

--- a/xbios/vidix/vdxqueryfourcc.ui
+++ b/xbios/vidix/vdxqueryfourcc.ui
@@ -1,0 +1,103 @@
+!iflang [english]
+
+
+!begin_node vdxQueryFourcc
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxQueryFourcc(!ldouble) - Request fourcc.
+
+!item [Opcode:]
+405 (0x0195)
+
+!item [Syntax:]
+int32_t vdxQueryFourcc ( vidix_fourcc_t *to ) ;
+
+!item [Description:]
+Select requested fourcc, width and height.
+Driver should answer - can it configure video memory for a given fourcc or not.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0 else ENOSYS.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxQueryFourcc]) ~ vdxConfigPlayback ~ vdxPlaybackCopyFrame ~
+vdxPlaybackFrameSelect ~ vdxQueryDMAStatus
+
+(!ende_liste)
+
+!begin_node Bindings for vdxQueryFourcc
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxQueryFourcc ( vidix_fourcc_t *to );
+!item [Assembler:]
+!begin_verbatim
+pea       to           ; Offset 2
+move.w    #405,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxQueryFourcc
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxQueryFourcc(!ldouble) - Request fourcc.
+
+!item [Xbiosnummer:]
+405 (0x0195)
+
+!item [Deklaration:]
+int32_t vdxQueryFourcc ( vidix_fourcc_t *to );
+
+!item [Beschreibung:]
+Select requested fourcc, width and heigth.
+Driver should answer - can it configure video memory for a given fourcc or not.
+
+!item [Ergebnis:]
+Driver should return 0 else ENOSYS.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxQueryFourcc]) ~ vdxConfigPlayback ~ vdxPlaybackCopyFrame ~
+vdxPlaybackFrameSelect ~ vdxQueryDMAStatus
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxQueryFourcc
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxQueryFourcc ( vidix_fourcc_t *to );
+!item [Assembler:]
+!begin_verbatim
+pea       to           ; Offset 2
+move.w    #405,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vdxqueryfourcc.ui
+++ b/xbios/vidix/vdxqueryfourcc.ui
@@ -24,7 +24,7 @@ Driver should return 0 else ENOSYS.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxQueryFourcc]) ~ vdxConfigPlayback ~ vdxPlaybackCopyFrame ~
@@ -75,7 +75,7 @@ Driver should return 0 else ENOSYS.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxQueryFourcc]) ~ vdxConfigPlayback ~ vdxPlaybackCopyFrame ~

--- a/xbios/vidix/vdxsetgrkeys.ui
+++ b/xbios/vidix/vdxsetgrkeys.ui
@@ -26,7 +26,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Group:]
-(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+VIDIX XBIOS extension
 
 !item [See also:]
 (!link [Binding] [Bindings for vdxSetGrKeys]) ~ vdxGetGrKeys
@@ -78,7 +78,7 @@ Driver should return 0.
 CT60/CTPCI hardware acceleration board and FireBee.
 
 !item [Gruppe:]
-(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+VIDIX-XBIOS-Erweiterung
 
 !item [Querverweis:]
 (!link [Binding] [Bindings f(!uumlaut)r vdxSetGrKeys]) ~ vdxGetGrKeys

--- a/xbios/vidix/vdxsetgrkeys.ui
+++ b/xbios/vidix/vdxsetgrkeys.ui
@@ -1,0 +1,105 @@
+!iflang [english]
+
+
+!begin_node vdxSetGrKeys
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)vdxSetGrKeys(!ldouble) - Set graphic keys.
+
+!item [Opcode:]
+411 (0x019b)
+
+!item [Syntax:]
+int32_t vdxSetGrKeys ( const vidix_grkey_t *grkey ) ;
+
+!item [Description:]
+This interface should be tuned but introduced for overlapped playback and video
+effects (TYPE_FX).
+
+(!B)Warning:(!b) This function is optional.
+
+!item [(!nolink [Return]) value:]
+Driver should return 0.
+
+!item [Availability:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Group:]
+(!link [VIDIX XBIOS extension] [VIDIX XBIOS extension])
+
+!item [See also:]
+(!link [Binding] [Bindings for vdxSetGrKeys]) ~ vdxGetGrKeys
+
+(!ende_liste)
+
+!begin_node Bindings for vdxSetGrKeys
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxSetGrKeys ( const vidix_grkey_t *grkey );
+!item [Assembler:]
+!begin_verbatim
+pea       grkey        ; Offset 2
+move.w    #411,-(sp)   ; Offset 0
+trap      #14          ; Call XBIOS
+addq.l    #6,sp        ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vdxSetGrKeys
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vdxSetGrKeys(!ldouble) - Set graphic keys.
+
+!item [Xbiosnummer:]
+411 (0x019b)
+
+!item [Deklaration:]
+int32_t vdxSetGrKeys ( const vidix_grkey_t *grkey );
+
+!item [Beschreibung:]
+This interface should be tuned but introduced for overlapped playback and video
+effects (TYPE_FX).
+
+(!B)Achtung:(!b) Diese Funktion ist optional.
+
+!item [Ergebnis:]
+Driver should return 0.
+
+!item [Verf(!uumlaut)gbar:]
+CT60/CTPCI hardware acceleration board and FireBee.
+
+!item [Gruppe:]
+(!link [VIDIX-XBIOS-Erweiterung] [VIDIX-XBIOS-Erweiterung])
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vdxSetGrKeys]) ~ vdxGetGrKeys
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r vdxSetGrKeys
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t vdxSetGrKeys ( const vidix_grkey_t *grkey );
+!item [Assembler:]
+!begin_verbatim
+pea       grkey        ; Offset 2
+move.w    #411,-(sp)   ; Offset 0
+trap      #14          ; XBIOS aufrufen
+addq.l    #6,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/vidix/vidix.u
+++ b/xbios/vidix/vidix.u
@@ -1,7 +1,7 @@
 !iflang [english]
 
 !begin_node VIDIX XBIOS extension
-!html_name VIDIX_XBIOS_extension
+!html_name vidix_xbios_extension
 
 VIDIX ((!B)VID(!b)eo (!B)I(!b)nterface for *ni(!B)X(!b)) is a programming interface for Unix-like
 operating systems that allows direct access to the framebuffer of a video
@@ -32,7 +32,7 @@ January 24, 2007.
 !else
 
 !begin_node VIDIX-XBIOS-Erweiterung
-!html_name VIDIX_XBIOS_Erweiterung
+!html_name vidix_xbios_extension
 
 VIDIX ((!B)VID(!b)eo (!B)I(!b)nterface for *ni(!B)X(!b)) is a programming interface for Unix-like
 operating systems that allows direct access to the framebuffer of a video

--- a/xbios/vidix/vidix.u
+++ b/xbios/vidix/vidix.u
@@ -1,0 +1,85 @@
+!iflang [english]
+
+!begin_node VIDIX XBIOS extension
+!html_name VIDIX_XBIOS_extension
+
+VIDIX ((!B)VID(!b)eo (!B)I(!b)nterface for *ni(!B)X(!b)) is a programming interface for Unix-like
+operating systems that allows direct access to the framebuffer of a video
+card. VIDIX integration inside TOS (for CT60/CTPCI/Firebee) was added on
+January 24, 2007.
+
+!begin_xlist [x vdxPlaybackFrameSelect] !compressed
+!item [(!bullet) vdxConfigPlayback~~~~~] Prepare BES (BackEnd Scaler).
+!item [(!bullet) vdxDestroy~~~~~~~~~~~~] Quit driver.
+!item [(!bullet) vdxGetCapability~~~~~~] Get capability.
+!item [(!bullet) vdxGetGrKeys~~~~~~~~~~] Get graphic keys.
+!item [(!bullet) vdxGetVersion~~~~~~~~~] Get version.
+!item [(!bullet) vdxInit~~~~~~~~~~~~~~~] Initialize driver.
+!item [(!bullet) vdxPlaybackCopyFrame~~] Copy frame with DMA.
+!item [(!bullet) vdxPlaybackFrameSelect] Prepare frame.
+!item [(!bullet) vdxPlaybackGetDeint~~~] Get interlacing.
+!item [(!bullet) vdxPlaybackGetEq~~~~~~] Get color correction.
+!item [(!bullet) vdxPlaybackOff~~~~~~~~] Deactivate BES (BackEnd Scaler).
+!item [(!bullet) vdxPlaybackOn~~~~~~~~~] Activate BES (BackEnd Scaler).
+!item [(!bullet) vdxPlaybackSetDeint~~~] Set interlacing.
+!item [(!bullet) vdxPlaybackSetEq~~~~~~] Set color correction.
+!item [(!bullet) vdxProbe~~~~~~~~~~~~~~] Probe the board.
+!item [(!bullet) vdxQueryDMAStatus~~~~~] Get DMA status.
+!item [(!bullet) vdxQueryFourcc~~~~~~~~] Request fourcc.
+!item [(!bullet) vdxSetGrKeys~~~~~~~~~~] Set graphic keys.
+!end_xlist
+
+!else
+
+!begin_node VIDIX-XBIOS-Erweiterung
+!html_name VIDIX_XBIOS_Erweiterung
+
+VIDIX ((!B)VID(!b)eo (!B)I(!b)nterface for *ni(!B)X(!b)) is a programming interface for Unix-like
+operating systems that allows direct access to the framebuffer of a video
+card. VIDIX integration inside TOS (for CT60/CTPCI/Firebee) was added on
+January 24, 2007.
+
+!begin_xlist [x vdxPlaybackFrameSelect] !compressed
+!item [(!bullet) vdxConfigPlayback~~~~~] Prepare BES (BackEnd Scaler).
+!item [(!bullet) vdxDestroy~~~~~~~~~~~~] Quit driver.
+!item [(!bullet) vdxGetCapability~~~~~~] Get capability.
+!item [(!bullet) vdxGetGrKeys~~~~~~~~~~] Get graphic keys.
+!item [(!bullet) vdxGetVersion~~~~~~~~~] Get version.
+!item [(!bullet) vdxInit~~~~~~~~~~~~~~~] Initialize driver.
+!item [(!bullet) vdxPlaybackCopyFrame~~] Copy frame with DMA.
+!item [(!bullet) vdxPlaybackFrameSelect] Prepare frame.
+!item [(!bullet) vdxPlaybackGetDeint~~~] Get interlacing.
+!item [(!bullet) vdxPlaybackGetEq~~~~~~] Get color correction.
+!item [(!bullet) vdxPlaybackOff~~~~~~~~] Deactivate BES (BackEnd Scaler).
+!item [(!bullet) vdxPlaybackOn~~~~~~~~~] Activate BES (BackEnd Scaler).
+!item [(!bullet) vdxPlaybackSetDeint~~~] Set interlacing.
+!item [(!bullet) vdxPlaybackSetEq~~~~~~] Set color correction.
+!item [(!bullet) vdxProbe~~~~~~~~~~~~~~] Probe the board.
+!item [(!bullet) vdxQueryDMAStatus~~~~~] Get DMA status.
+!item [(!bullet) vdxQueryFourcc~~~~~~~~] Request fourcc.
+!item [(!bullet) vdxSetGrKeys~~~~~~~~~~] Set graphic keys.
+!end_xlist
+
+
+!endif
+
+!include xbios/vidix/vdxconfigplayback.ui
+!include xbios/vidix/vdxdestroy.ui
+!include xbios/vidix/vdxgetcapability.ui
+!include xbios/vidix/vdxgetgrkeys.ui
+!include xbios/vidix/vdxgetversion.ui
+!include xbios/vidix/vdxinit.ui
+!include xbios/vidix/vdxplaybackcopyframe.ui
+!include xbios/vidix/vdxplaybackframeselect.ui
+!include xbios/vidix/vdxplaybackgetdeint.ui
+!include xbios/vidix/vdxplaybackgeteq.ui
+!include xbios/vidix/vdxplaybackoff.ui
+!include xbios/vidix/vdxplaybackon.ui
+!include xbios/vidix/vdxplaybacksetdeint.ui
+!include xbios/vidix/vdxplaybackseteq.ui
+!include xbios/vidix/vdxprobe.ui
+!include xbios/vidix/vdxquerydmastatus.ui
+!include xbios/vidix/vdxqueryfourcc.ui
+!include xbios/vidix/vdxsetgrkeys.ui
+
+!end_node

--- a/xbios/xbios.u
+++ b/xbios/xbios.u
@@ -200,6 +200,7 @@ Die Funktion liefert als Ergebnis einen Wert vom Datentyp int32_t.
 !include xbios/sound/sound.u
 !include xbios/spezial/spezial.u
 !include xbios/tastatur/tastatur.u
+!include xbios/vidix/vidix.u
 
 
 !include xbios/xbios_f.u


### PR DESCRIPTION
Sources:
- [VIDIX project website](https://sourceforge.net/projects/vidix/)
- [XBIOS VIDIX](https://github.com/ggnkua/Atari_ST_Sources/blob/16dc8ae257001c6b17da43e7e11c68d382bbad3c/ASM/Various/Didier%20Mequignon/tos_drivers/doc/vidix_xbios.txt#L4)