### PR TITLE
Add vq_driver_info

### DIFF
--- a/gem/vdi/escape/graphic/graphic.u
+++ b/gem/vdi/escape/graphic/graphic.u
@@ -35,6 +35,8 @@ Outputs image data on a printer
 Gets information about v_bit_image
 !item [(!bullet) vq_calibrate]
 Tests colour calibration
+!item [(!bullet) vq_driver_info]
+Gets information about a printer driver
 !item [(!bullet) vq_margins]
 Inquires printer margins
 !item [(!bullet) vq_page_name]
@@ -95,6 +97,8 @@ Bildinformationen auf Drucker ausgeben.
 Informationen (!uumlaut)ber v_bit_image ermitteln.
 !item [(!bullet) vq_calibrate]
 Farbkalibrierung testen.
+!item [(!bullet) vq_driver_info]
+Informationen (!uumlaut)ber einen Druckertreiber ermitteln.
 !item [(!bullet) vq_margins]
 Druckerr(!aumlaut)nder erfragen.
 !item [(!bullet) vq_page_name]
@@ -122,6 +126,7 @@ Workstations des VDI ~ Style-Guidelines
 
 !include gem/vdi/escape/graphic/vq_bit_image.ui
 !include gem/vdi/escape/graphic/vq_calibrate.ui
+!include gem/vdi/escape/graphic/vq_driver_info.ui
 !include gem/vdi/escape/graphic/vq_margins.ui
 !include gem/vdi/escape/graphic/vq_page_name.ui
 !include gem/vdi/escape/graphic/vq_prn_scaling.ui

--- a/gem/vdi/escape/graphic/vq_driver_info.ui
+++ b/gem/vdi/escape/graphic/vq_driver_info.ui
@@ -1,0 +1,276 @@
+!iflang [english]
+
+!begin_node vq_driver_info
+
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Inquire driver info(!ldouble) - Obtain information about a printer
+driver.
+
+!item [Opcode:]
+5 (Escape 2101)
+
+!item [Syntax:]
+int16_t vq_driver_info ( int16_t handle, int16_t *lib, int16_t *drv, 
+                         int16_t *plane, int16 *attr, int8_t *name );
+
+!item [Description:]
+The call vq_driver_info returns information about a printer driver and
+available features of the current library. The following apply:
+
+!begin_xlist !compressed [handle]
+!item [Parameter]
+Meaning
+!item [~]
+~
+!item [handle]
+Workstation identifier
+!item [lib]
+Library version number
+!item [drv]
+Driver version number
+!item [plane]
+Number of planes
+!begin_table [l l l]
+1 !! - !! Monochrome
+3 !! - !! CMY
+4 !! - !! CMYK
+!end_table
+!item [attr]
+Supported attributes
+!begin_xlist !compressed [Bit 6..15:]
+!item [Bit 0:] Four color
+!item [Bit 1:] Negative
+!item [Bit 2:] Mirror
+!item [Bit 3 & 4:] Multiple copies
+!begin_table [l l l]
+0 !! - !! No
+1 !! - !! Hardware
+2 !! - !! Software
+3 !! - !! Reserved
+!end_table
+!item [Bit 5:] Landscape
+!item [Bit 6..15:] Reserved
+!end_xlist
+!item [name]
+Name of the driver as up to 27 characters (26 + NULL)
+!end_xlist
+
+(!B)Note:(!b) This function allows to determine if the new vq_margin and
+vq_bit_image functions (Escape >= 2100) are available.
+
+!item [(!nolink [Return]) value:]
+0: Function does not exist.
+
+!item [Availability:]
+Available with new drivers from Thierry Rodolfo.
+
+!item [Group:]
+Special graphic functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vq_driver_info]) ~ vq_margin ~
+vq_bit_image
+
+(!ende_liste)
+!end_node
+
+
+
+!begin_node Bindings for vq_driver_info
+!ignore_index
+
+(!begin_liste) [GEM-Arrays]
+
+!item [C:]
+int16_t v_driver_info ( int16_t handle, int16_t *lib, int16_t *drv,
+                  int16_t *plane, int16_t *attr, int8_t *name );
+
+!item [Binding:]
+!begin_verbatim
+int16_t v_driver_info (int16_t handle, int16_t *lib, int16_t *drv,
+                  int16_t *plane, int16_t *attr, int8_t *name )
+{
+   int16_t tmp;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 2101;
+   contrl[6] = handle;
+
+   vdi ();
+
+   *lib   = intout[1];
+   *drv   = intout[2];
+   *plane = intout[3];
+   *attr  = intout[4];
+   for (tmp = 0; tmp < 26; tmp++)
+     name[tmp] = intout[tmp+5];
+   name[26] = 0;
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0]     !! 5     # Function Opcode
+contrl+2  !! contrl[1]     !! 0     # Entry in ptsin
+contrl+4  !! contrl[2]     !! 0     # Entry in ptsout
+contrl+6  !! contrl[3]     !! 0     # Entry in intin
+contrl+8  !! contrl[4]     !! 31    # Entry in intout
+contrl+10 !! contrl[5]     !! 2101  # Escape/Sub-opcode
+contrl+12 !! contrl[6]     !! handle
+intout    !! intout[0]     !! Return Value
+intout+2  !! intout[1]     !! lib
+intout+4  !! intout[2]     !! drv
+intout+6  !! intout[3]     !! plane
+intout+8  !! intout[4]     !! attr
+intout+10 !! intout[5..30] !! name[0..25]
+!end_table
+
+(!ende_liste)
+!end_node
+
+!else
+
+!begin_node vq_driver_info
+
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Inquire Driver Info(!ldouble) - ermittelt Informationen (!uumlaut)ber einen Druckertreiber.
+
+!item [VDI-Nummer:]
+5 (Escape 2101)
+
+!item [Deklaration:]
+int16_t vq_driver_info ( int16_t handle, int16_t *lib, int16_t *drv,
+                         int16_t *plane, int16_t *attr, int8_t *name );
+
+!item [Beschreibung:]
+Die Funktion ermittelt Informationen (!uumlaut)ber einen Druckertreiber.
+Es gilt:
+
+!begin_xlist !compressed [element_num]
+!item [Parameter]
+Bedeutung
+!item [~]
+~
+!item [handle]
+Kennung der Workstation
+!item [lib]
+Versionsnummer der Bibliothek
+!item [drv]
+Versionsnummer der Treiber
+!item [plane]
+Anzahl der Planes
+!begin_table [l l l]
+1 !! - !! Monochrom
+3 !! - !! CMY
+4 !! - !! CMYK
+!end_table
+!item [attr]
+Attribute
+!begin_xlist !compressed [Bit 6..15:]
+!item [Bit 0:] Vierfarbdruck wird unterst(!uumlaut)tzt
+!item [Bit 1:] Negative wird unterst(!uumlaut)tzt
+!item [Bit 2:] Mirror wird unterst(!uumlaut)tzt
+!item [Bit 3 & 4:] Multiple copies
+!begin_table [l l l]
+1 !! - !! No
+2 !! - !! Hardware
+3 !! - !! Software
+4 !! - !! Reserviert
+!end_table
+!item [Bit 5:] Landscape wird unterst(!uumlaut)tzt
+!item [Bit 6..15:] Reserviert
+!end_xlist
+!item [name]
+Name der Treiber als maximal 27 Zeichen lange Zeichenkette (26 + NULL)
+!end_xlist
+
+(!B)Hinweis:(!b) This function allows to determine if the new vq_margin and
+vq_bit_image functions (Escape >= 2100) are available. 
+
+!item [Ergebnis:]
+0: Funktion existiert nicht.
+
+!item [Verf(!uumlaut)gbar:]
+Treiber von Thierry Rodolfo
+
+!item [Gruppe:]
+Grafikspezial-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vq_driver_info]) ~ vq_margin ~
+vq_bit_image
+
+(!ende_liste)
+!end_node
+
+
+
+!begin_node Bindings f(!uumlaut)r vq_driver_info
+!ignore_index
+
+(!begin_liste) [Umsetzung]
+
+!item [C:]
+int16_t vq_driver_info ( int16_t handle, int16_t *lib, int16_t *drv,
+                   int16_t *plane, int16_t *attr, int8_t *name );
+
+!item [Umsetzung:]
+!begin_verbatim
+int16_t vq_driver_info (int16_t handle, int16_t *lib, int16_t *drv,
+                  int16_t *plane, int16_t *attr, int8_t *name)
+{
+   int16_t tmp;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 2101;
+   contrl[6] = handle;
+
+   vdi ();
+
+   *lib   = intout[1];
+   *drv   = intout[2]; 
+   *plane = intout[3];
+   *attr  = intout[4];
+   for (tmp = 0; tmp < 26; tmp++)
+     name[tmp] = intout[tmp+5];
+   name[26] = 0;
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Adresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0]     !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1]     !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2]     !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3]     !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4]     !! 31    # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5]     !! 2101  # Escape/Sub-Opcode
+contrl+12 !! contrl[6]     !! handle
+intout    !! intout[0]     !! Return-Wert
+intout+2  !! intout[1]     !! lib
+intout+4  !! intout[2]     !! drv
+intout+6  !! intout[3]     !! plane
+intout+8  !! intout[4]     !! attr
+intout+10 !! intout[5..30] !! name[0..25]
+!end_table
+
+(!ende_liste)
+!end_node
+
+!endif


### PR DESCRIPTION
Describes vq_driver_info() from "new" color drivers by Thierry Rodolfo

Btw I can't find `vq_margins` (5,2100) anywhere. (I looked at NVDI 3, 4.1 & 5 documentation) 

On the one hand, both tos.hyp and gemlib include `vq_margins`, but on the other hand it seems that `vq_margin` is the right binding.