### PR TITLE
Add vq_image_type

### DIFF
--- a/gem/vdi/escape/graphic/graphic.u
+++ b/gem/vdi/escape/graphic/graphic.u
@@ -37,6 +37,8 @@ Gets information about v_bit_image
 Tests colour calibration
 !item [(!bullet) vq_driver_info]
 Gets information about a printer driver
+!item [(!bullet) vq_image_type]
+Gets type of a bitmap file
 !item [(!bullet) vq_margins]
 Inquires printer margins
 !item [(!bullet) vq_page_name]
@@ -99,6 +101,8 @@ Informationen (!uumlaut)ber v_bit_image ermitteln.
 Farbkalibrierung testen.
 !item [(!bullet) vq_driver_info]
 Informationen (!uumlaut)ber einen Druckertreiber ermitteln.
+!item [(!bullet) vq_image_type]
+Typ einer Bitmap-Datei ermitteln.
 !item [(!bullet) vq_margins]
 Druckerr(!aumlaut)nder erfragen.
 !item [(!bullet) vq_page_name]
@@ -127,6 +131,7 @@ Workstations des VDI ~ Style-Guidelines
 !include gem/vdi/escape/graphic/vq_bit_image.ui
 !include gem/vdi/escape/graphic/vq_calibrate.ui
 !include gem/vdi/escape/graphic/vq_driver_info.ui
+!include gem/vdi/escape/graphic/vq_image_type.ui
 !include gem/vdi/escape/graphic/vq_margins.ui
 !include gem/vdi/escape/graphic/vq_page_name.ui
 !include gem/vdi/escape/graphic/vq_prn_scaling.ui

--- a/gem/vdi/escape/graphic/vq_image_type.ui
+++ b/gem/vdi/escape/graphic/vq_image_type.ui
@@ -1,0 +1,238 @@
+!iflang [english]
+
+!begin_node vq_image_type
+
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Inquire image type(!ldouble) - Obtain type of a bitmap file.
+
+!item [Opcode:]
+5 (Escape 2105)
+
+!item [Syntax:]
+int16_t vq_image_type ( int16_t handle, int8_t *filename, BIT_IMAGE *image )
+
+!item [Description:]
+The call vq_image_type obtains the image type of the file whose full pathname
+is specified by (!I)filename(!i), and writes information into the structure
+pointed to by (!I)image(!i) if its type is supported by v_bit_image. The
+following apply:
+
+!begin_xlist !compressed [Parameter]
+!item [Parameter]
+Meaning
+!item [~]
+~
+!item [handle]
+Workstation identifier
+!item [filename]
+Pointer to the name
+!item [image]
+Pointer to a BIT_IMAGE structure
+!end_xlist
+
+(!B)Note:(!b) Currently the returned type is based on the file extension.
+
+!item [(!nolink [Return]) value:]
+The function can return the following values:
+!begin_xlist !compressed [1 :]
+!item [0 :]
+Unknown
+!item [1 :]
+IMG
+!item [2 :]
+TGA
+!end_xlist
+
+!item [Availability:]
+Available with new drivers from Thierry Rodolfo.
+
+!item [Group:]
+Special graphic functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vq_image_type]) ~ v_bit_image ~
+vq_bit_image ~ vq_driver_info
+
+(!ende_liste)
+!end_node
+
+
+
+!begin_node Bindings for vq_image_type
+!ignore_index
+
+(!begin_liste) [GEM-Arrays]
+
+!item [C:]
+int16_t vq_image_type ( int16_t handle, int8_t *filename, BIT_IMAGE *image )
+
+!item [Binding:]
+!begin_verbatim
+int16_t vq_image_type ( int16_t handle,
+   int8_t *filename, BIT_IMAGE *image )
+{
+   int16_t tmp;
+
+   ptsin[0..1] = image;
+
+   tmp = 0;
+   while (intin[tmp++] = *filename++)
+      ;
+   intin[tmp++] = 0;
+
+   contrl[0] = 5;
+   contrl[1] = 1;
+   contrl[3] = tmp;
+   contrl[5] = 2105;
+   contrl[6] = handle;
+
+   vdi ();
+
+   return ( intout[1] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0]    !! 5     # Function opcode
+contrl+2  !! contrl[1]    !! 1     # Entry in ptsin
+contrl+4  !! contrl[2]    !! 0     # Entry in ptsout
+contrl+6  !! contrl[3]    !! n+1   # Entry in intin
+contrl+8  !! contrl[4]    !! 2     # Entry in intout
+contrl+10 !! contrl[5]    !! 2105  # Escape/Sub-opcode
+contrl+12 !! contrl[6]    !! handle
+intin     !! intin[0..n]  !! filename with NULL-byte
+ptsin     !! ptsin[0..1]  !! image
+intout    !! intout[0]    !! Availability
+intout+2  !! intout[1]    !! Return Value
+!end_table
+
+(!B)Note:(!b) If intout[0] contains the value 0, the function is not available.
+
+(!ende_liste)
+!end_node
+
+!else
+
+!begin_node vq_image_type
+
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Inquire Image Type(!ldouble) - Typ einer Bitmap-Datei ermitteln.
+
+!item [VDI-Nummer:]
+5 (Escape 2105)
+
+!item [Deklaration:]
+int16_t vq_image_type ( int16_t handle, int8_t *filename, BIT_IMAGE *image )
+
+!item [Beschreibung:]
+The call vq_image_type obtains the image type of the file whose full pathname
+is specified by (!I)filename(!i), and writes information into the structure
+pointed to by (!I)image(!i) if its type is supported by v_bit_image. The
+following apply:
+
+!begin_xlist !compressed [Parameter]
+!item [Parameter]
+Bedeutung
+!item [~]
+~
+!item [handle]
+Kennung der Workstation
+!item [filename]
+Zeiger auf Datei-Namen
+!item [image]
+Zeiger auf BIT_IMAGE-Struktur
+!end_xlist
+
+(!B)Note:(!b) Currently the returned type is based on the file extension.
+
+!item [Ergebnis:]
+Die Funktion kann folgende R(!uumlaut)ckgabewerte liefern:
+!begin_xlist !compressed [1 :]
+!item [0 :]
+Unbekannt
+!item [1 :]
+IMG
+!item [2 :]
+TGA
+!end_xlist
+
+!item [Verf(!uumlaut)gbar:]
+Treiber von Thierry Rodolfo.
+
+!item [Gruppe:]
+Grafikspezial-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vq_image_type]) ~ v_bit_image ~
+vq_bit_image ~ vq_driver_info
+
+(!ende_liste)
+!end_node
+
+
+
+!begin_node Bindings f(!uumlaut)r vq_image_type
+!ignore_index
+
+(!begin_liste) [Umsetzung]
+
+!item [C:]
+int16_t vq_image_type ( int16_t handle, int8_t *filename, BIT_IMAGE *image )
+
+!item [Umsetzung:]
+!begin_verbatim
+int16_t vq_image_type ( int16_t handle,
+   int8_t *filename, BIT_IMAGE *image )
+{
+   int16_t tmp;
+
+   ptsin[0..1] = image;
+
+   tmp = 0;
+   while (intin[tmp++] = *filename++)
+      ;
+   intin[tmp++] = 0;
+
+   contrl[0] = 5;
+   contrl[1] = 1;
+   contrl[3] = tmp;
+   contrl[5] = 2105;
+   contrl[6] = handle;
+
+   vdi ();
+
+   return ( intout[1] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Adresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0]    !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1]    !! 1     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2]    !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3]    !! n+1   # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4]    !! 2     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5]    !! 2105  # Escape/Sub-Opcode
+contrl+12 !! contrl[6]    !! handle
+intin     !! intin[0..n]  !! filename with NULL-byte
+ptsin     !! ptsin[0..1]  !! image
+intout    !! intout[0]    !! Verf(!uumlaut)gbar
+intout+2  !! intout[1]    !! Return-Wert
+!end_table
+
+(!B)Hinweis:(!b) Falls intout[0] den Wert 0 enth(!aumlaut)lt, steht die
+Funktion nicht zur Verf(!uumlaut)gung.
+
+(!ende_liste)
+!end_node
+
+!endif

--- a/gem/vdi/structures/bit_image.ui
+++ b/gem/vdi/structures/bit_image.ui
@@ -1,0 +1,31 @@
+!iflang [english]
+
+!begin_node BIT_IMAGE
+
+!begin_verbatim
+typedef struct
+{
+   int16_t   nbplanes;
+   int16_t   width;
+   int16_t   height;
+} BIT_IMAGE;
+!end_verbatim
+
+!end_node
+
+!else
+
+!begin_node BIT_IMAGE
+
+!begin_verbatim
+typedef struct
+{
+   int16_t   nbplanes;
+   int16_t   width;
+   int16_t   height;
+} BIT_IMAGE;
+!end_verbatim
+!end_node
+
+
+!endif

--- a/gem/vdi/structures/structures.u
+++ b/gem/vdi/structures/structures.u
@@ -10,6 +10,7 @@
 !begin_node VDIPB
 !include gem/vdi/structures/vdipb.ui
 !end_node
+!include gem/vdi/structures/bit_image.ui
 !include gem/vdi/structures/color_entry.ui
 !include gem/vdi/structures/color_rgb.ui
 !include gem/vdi/structures/color_tab.ui


### PR DESCRIPTION
Note: Comments from `VDIBIND.C` are wrong:
```
/*		ptsin[0]=img & 0xffff;				*/
/*		ptsin[1]=img>>16;				*/
```

Actual source code:
```
((long *)(vdipb.ptsin))[0]=(long)image;
```

Thus, ptsin[0] contains the high-word and ptsin[1] contains the low-word