### PR TITLE
Fix typos (wrong character encoding)

### DIFF
--- a/gem/vdi/tcvdi/vrun_parallel.ui
+++ b/gem/vdi/tcvdi/vrun_parallel.ui
@@ -151,7 +151,7 @@ Nur verf(!uumlaut)gbar auf MATRIX Karte im TC Modus.
 TC-VDI-Funktionen
 
 !item [Querverweis:]
-(!link [Binding] [Bindings f(!uumlaut)r vrun_parallel]) ~ vrun_rect ~ vrun_triangle
+(!link [Binding] [Bindings f(!uumlaut)r vrun_parallel]) ~ vrun_rect ~ vrun_triangle
 
 (!ende_liste)
 !end_node

--- a/gem/vdi/tcvdi/vrun_rect.ui
+++ b/gem/vdi/tcvdi/vrun_rect.ui
@@ -141,7 +141,7 @@ Nur verf(!uumlaut)gbar auf MATRIX Karte im TC Modus.
 TC-VDI-Funktionen
 
 !item [Querverweis:]
-(!link [Binding] [Bindings f(!uumlaut)r vrun_rect]) ~ vrun_parallel ~ vrun_triangle
+(!link [Binding] [Bindings f(!uumlaut)r vrun_rect]) ~ vrun_parallel ~ vrun_triangle
 
 (!ende_liste)
 !end_node


### PR DESCRIPTION
Was ISO-8859-1 instead of ASCII, should be fixed now