### PR TITLE
Add BioNet functions (single page)

### DIFF
--- a/gemdos/bionet.u
+++ b/gemdos/bionet.u
@@ -1,0 +1,187 @@
+!iflang [english]
+
+
+!begin_node NAP BioNet100
+!html_name nap_bionet100
+!label nap_io
+!label nap_in_s
+!label nap_out_s
+
+BioNet was a GEMDOS network extension from BIODATA GmbH.
+
+Three functions are added to the GEMDOS, which allow the BioNet Client to
+communicate with a 'Nap' hosted by the Nap Server. A server can run multiple
+Nap, each of them is identified by a (!I)nap_handle(!i) associated to a
+internal NAP_COM structure.
+
+!begin_xlist [Number]
+!item [Number]
+Meaning
+!item [91]
+(!B)nap_io()(!b) Nap input/output (!nl)
+This function is the legacy function for bidirectional communication with the
+server. (!I)nap_io(!i) is divided into the (!I)nap_in_s(!i) and
+(!I)nap_out_s(!i) functions, which are executed one after the other. (!nl)
+The return value is the number of returned bytes.
+
+Syntax: (!nl)
+int32_t gemdos( 91, int16_t nap_handle, int8_t *buf_out, int32_t len_out,
+                       int8_t *buf_in, int32_t len_in);
+
+!item [130]
+(!B)nap_in_s()(!b) Nap input (!nl)
+This function writes data to the server. (!nl)
+Returns the number of transferred bytes.
+
+Syntax: (!nl)
+int32_t gemdos( 130, int16_t nap_handle, int32_t mode, int32_t count, int8_t *buffer);
+
+!item [131]
+(!B)nap_out_s()(!b) Nap output (!nl)
+This function reads data from the server. (!nl)
+Returns the number of transferred bytes.
+
+Syntax: (!nl)
+int32_t gemdos( 131, int16_t nap_handle, int32_t mode, int32_t count, int8_t *buffer);
+
+!end_xlist
+
+The (!I)mode(!i) parameter is stored into the field (!I)nap_wert(!i) by the
+server. Values from 0 to -9L are reserved by BioNet100. The client can set
+(!I)mode(!i) to a value less than -9L to acquire a lock, or to 0L to release
+the lock. If no transfer is required, (!I)count(!i) should be set to 0.
+
+The NAP_COM structure is defined as follows:
+
+!begin_verbatim
+typedef struct
+{
+  int16_t    nap_handle;   /* Nap handle that identifies a program   */
+  int32_t    nummer;       /* BioNet client number                   */
+  int16_t    status;       /* Status of the client                   */
+                           /*   Bit 0: nap_in_s is active            */ 
+                           /*   Bit 1: nap_out_s is active           */
+                           /*   Bit 2: first data burst              */
+                           /*   Bit 3: last data burst               */
+                           /*   Bit 4: fatal error                   */
+  int32_t    ret_wert;     /* If bit 4 of status is set, specifies   */
+                           /* the message sent to the client:        */
+                           /*   0 = 'Cant repair protocoll-error...' */ 
+                           /*   1 = 'Repairing protocoll-error...'   */
+  int32_t    nap_wert;     /* If nonzero, prevents other client to   */
+                           /* communicate with this Nap. By default, */
+                           /* set to nummer. This value is returned  */
+                           /* as error-code to other client          */
+  int8_t    *in_buffer;    /* Pointer to the data buffer that holds  */
+                           /* either the data to read from nap_in_s, */
+                           /* or command data for nap_out_s          */
+  int8_t    *out_buffer;   /* Pointer to the data buffer that holds  */
+                           /* the data to send to the client through */
+                           /* nap_out_s.                             */
+  int32_t    ges_count;    /* Total number of data to send/receive   */
+  int32_t    akt_count;    /* Current number of data to send/receive */
+}
+!end_verbatim
+
+
+(!B)Note:(!b) The BioNet server complies to the XBRA protocol with ID 'BioS'.
+
+See also: GEMDOS ~  (!link [BIOS function list][BIOS function list]) ~
+XBIOS function list
+!end_node
+
+
+!else
+
+
+!begin_node NAP BioNet100
+!html_name nap_bionet100
+!label nap_io
+!label nap_in_s
+!label nap_out_s
+
+BioNet was a GEMDOS network extension from BIODATA GmbH.
+
+Three functions are added to the GEMDOS, which allow the BioNet Client to
+communicate with a 'Nap' hosted by the Nap Server. A server can run multiple
+Nap, each of them is identified by a (!I)nap_handle(!i) associated to a
+internal NAP_COM structure.
+
+!begin_xlist [Number]
+!item [Number]
+Meaning
+!item [91]
+(!B)nap_io()(!b) Nap input/output (!nl)
+This function is the legacy function for bidirectional communication with the
+server. (!I)nap_io(!i) is divided into the (!I)nap_in_s(!i) and
+(!I)nap_out_s(!i) functions, which are executed one after the other. (!nl)
+The return value is the number of returned bytes.
+
+Syntax: (!nl)
+int32_t gemdos( 91, int16_t nap_handle, int8_t *buf_out, int32_t len_out,
+                       int8_t *buf_in, int32_t len_in);
+
+!item [130]
+(!B)nap_in_s()(!b) Nap input (!nl)
+This function writes data to the server. (!nl)
+Returns the number of transferred bytes.
+
+Syntax: (!nl)
+int32_t gemdos( 130, int16_t nap_handle, int32_t mode, int32_t count, int8_t *buffer);
+
+!item [131]
+(!B)nap_out_s()(!b) Nap output (!nl)
+This function reads data from the server. (!nl)
+Returns the number of transferred bytes.
+
+Syntax: (!nl)
+int32_t gemdos( 131, int16_t nap_handle, int32_t mode, int32_t count, int8_t *buffer);
+
+!end_xlist
+
+The (!I)mode(!i) parameter is stored into the field (!I)nap_wert(!i) by the
+server. Values from 0 to -9L are reserved by BioNet100. The client can set
+(!I)mode(!i) to a value less than -9L to acquire a lock, or to 0L to release
+the lock. If no transfer is required, (!I)count(!i) should be set to 0.
+
+The NAP_COM structure is defined as follows:
+
+!begin_verbatim
+typedef struct
+{
+  int16_t    nap_handle;   /* Nap handle that identifies a program   */
+  int32_t    nummer;       /* BioNet client number                   */
+  int16_t    status;       /* Status of the client                   */
+                           /*   Bit 0: nap_in_s is active            */ 
+                           /*   Bit 1: nap_out_s is active           */
+                           /*   Bit 2: first data burst              */
+                           /*   Bit 3: last data burst               */
+                           /*   Bit 4: fatal error                   */
+  int32_t    ret_wert;     /* If bit 4 of status is set, specifies   */
+                           /* the message sent to the client:        */
+                           /*   0 = 'Cant repair protocoll-error...' */ 
+                           /*   1 = 'Repairing protocoll-error...'   */
+  int32_t    nap_wert;     /* If nonzero, prevents other client to   */
+                           /* communicate with this Nap. By default, */
+                           /* set to nummer. This value is returned  */
+                           /* as error-code to other client          */
+  int8_t    *in_buffer;    /* Pointer to the data buffer that holds  */
+                           /* either the data to read from nap_in_s, */
+                           /* or command data for nap_out_s          */
+  int8_t    *out_buffer;   /* Pointer to the data buffer that holds  */
+                           /* the data to send to the client through */
+                           /* nap_out_s.                             */
+  int32_t    ges_count;    /* Total number of data to send/receive   */
+  int32_t    akt_count;    /* Current number of data to send/receive */
+}
+!end_verbatim
+
+
+(!B)Note:(!b) The BioNet server complies to the XBRA protocol with ID 'BioS'.
+
+Querverweis: GEMDOS ~  (!link [BIOS-Funktionsliste][BIOS-Funktionsliste]) ~
+XBIOS-Funktionsliste
+!end_node
+
+
+!endif

--- a/gemdos/gemdos.u
+++ b/gemdos/gemdos.u
@@ -2137,6 +2137,7 @@ bios ~ xbios ~ GEMDOS ~ (!link [Dispatcher][GEMDOS-Dispatcher])
 
 !include gemdos/argv.u
 !include gemdos/c_task.u
+!include gemdos/bionet.u
 !include gemdos/powerdos.u
 !include gemdos/tekbios.u
 !include gemdos/gemdos_f.u

--- a/gemdos/gemdos_f.u
+++ b/gemdos/gemdos_f.u
@@ -69,6 +69,7 @@ dez !! hex !! Function !! present
  79 !! 0x4F !! Fsnext       !! (!nolink [TOS])
  86 !! 0x56 !! Frename      !! (!nolink [TOS])
  87 !! 0x57 !! Fdatime      !! (!nolink [TOS])
+ 91 !! 0x5B !! nap_io       !! NAP BioNet100
  92 !! 0x5C !! Flock        !! 
 !hline
  96 !! 0x60 !! Nversion     !! 
@@ -137,9 +138,9 @@ dez !! hex !! Function !! present
 128 !! 0x80 !! Puserid        !! PowerDOS
 129 !! 0x81 !! Ppriority      !! (!nolink [PowerDOS])
 130 !! 0x82 !! (!link [Pgetpid][P_getpid])        !! (!nolink [PowerDOS])
-130 !! 0x82 !! nap_in_s       !! NAP BioNet100
+130 !! 0x82 !! nap_in_s       !! (!nolink [NAP BioNet100])
 131 !! 0x83 !! (!link [Pgetppid][P_getppid])       !! (!nolink [PowerDOS])
-131 !! 0x83 !! nap_out_s      !! NAP BioNet100
+131 !! 0x83 !! nap_out_s      !! (!nolink [NAP BioNet100])
 132 !! 0x84 !! Pgetpd         !! (!nolink [PowerDOS])
 133 !! 0x85 !! Pfindpid       !! (!nolink [PowerDOS])
 134 !! 0x86 !! Pprocinf       !! (!nolink [PowerDOS])
@@ -418,6 +419,7 @@ dez !! hex !! Funktionsname !! vorhanden
  79 !! 0x4F !! Fsnext       !! (!nolink [TOS])
  86 !! 0x56 !! Frename      !! (!nolink [TOS])
  87 !! 0x57 !! Fdatime      !! (!nolink [TOS])
+ 91 !! 0x5B !! nap_io       !! NAP BioNet100
  92 !! 0x5C !! Flock        !! 
 !hline
  96 !! 0x60 !! Nversion     !! 
@@ -486,9 +488,9 @@ dez !! hex !! Funktionsname !! vorhanden
 128 !! 0x80 !! Puserid        !! PowerDOS
 129 !! 0x81 !! Ppriority      !! (!nolink [PowerDOS])
 130 !! 0x82 !! (!link [Pgetpid][P_getpid])        !! (!nolink [PowerDOS])
-130 !! 0x82 !! nap_in_s       !! NAP BioNet100
+130 !! 0x82 !! nap_in_s       !! (!nolink [NAP BioNet100])
 131 !! 0x83 !! (!link [Pgetppid][P_getppid])       !! (!nolink [PowerDOS])
-131 !! 0x83 !! nap_out_s      !! NAP BioNet100
+131 !! 0x83 !! nap_out_s      !! (!nolink [NAP BioNet100])
 132 !! 0x84 !! Pgetpd         !! (!nolink [PowerDOS])
 133 !! 0x85 !! Pfindpid       !! (!nolink [PowerDOS])
 134 !! 0x86 !! Pprocinf       !! (!nolink [PowerDOS])


### PR DESCRIPTION
Added a single page about nap_in_s and nap_in_out. I discovered nap_io in NAP_2.C (thanks to Atari Document Archive)

There are only about 220 functions left to describe... if we choose to not document others extensions such as SCSIDRV, TapeBIOS, TRAP_10, ProSOUND, XtendTOS, SuperCharger, MIDISHARE, MIDI_COM, MICRO RTX for now