### PR TITLE
Fix some scancode mappings

### DIFF
--- a/anhang/anhang/scan-code.ui
+++ b/anhang/anhang/scan-code.ui
@@ -61,8 +61,8 @@ Scancode !! Germany !! USA !! Standard (!nolink [VDI]) code
  37 !! K                !! K           !! K
  38 !! L                !! L           !! L
  39 !! ™                !! ;           !! ;
- 40 !! Ž                !! ,           !! ,
- 41 !! #                !! ~           !! ~
+ 40 !! Ž                !! '           !! '
+ 41 !! #                !! `           !! `
  42 !! Left Shift       !! ~           !! ~
  43 !! ~                !! \           !! \
  44 !! Y                !! Z           !! Z
@@ -75,8 +75,8 @@ Scancode !! Germany !! USA !! Standard (!nolink [VDI]) code
  51 !! ,                !! ,           !! ,
  52 !! .                !! .           !! .
  53 !! -                !! /           !! /
- 54 !! Right Shift      !!             !! PRINT SCREEN
- 55 !! Not present      !! Not present !! ~
+ 54 !! Right Shift      !! ~           !! ~
+ 55 !! Not present      !! Not present !! PRINT SCREEN
  56 !! Alternate        !! ~           !! ~
  57 !! Space            !! ~           !! ~
  58 !! CapsLock         !! ~           !! ~
@@ -120,21 +120,21 @@ Scancode !! Germany !! USA !! Standard (!nolink [VDI]) code
  96 !! <                !! Not present !! F23
  97 !! Undo             !! ~           !! F24
  98 !! Help             !! ~           !! F25
- 99 !! ( (Num-pad) !! ~           !! F26
-100 !! ) (Num-pad) !! ~           !! F27
-101 !! / (Num-pad) !! ~           !! F28
-102 !! * (Num-pad) !! ~           !! F29
-103 !! 7 (Num-pad) !! ~           !! F30
-104 !! 8 (Num-pad) !! ~           !! F31
-105 !! 9 (Num-pad) !! ~           !! F32
-106 !! 4 (Num-pad) !! ~           !! F33
-107 !! 5 (Num-pad) !! ~           !! F34
-108 !! 6 (Num-pad) !! ~           !! F35
-109 !! 1 (Num-pad) !! ~           !! F36
-110 !! 2 (Num-pad) !! ~           !! F37
-111 !! 3 (Num-pad) !! ~           !! F38
-112 !! 0 (Num-pad) !! ~           !! F39
-113 !! . (Num-pad) !! ~           !! F40
+ 99 !! ( (Num-pad)      !! ~           !! F26
+100 !! ) (Num-pad)      !! ~           !! F27
+101 !! / (Num-pad)      !! ~           !! F28
+102 !! * (Num-pad)      !! ~           !! F29
+103 !! 7 (Num-pad)      !! ~           !! F30
+104 !! 8 (Num-pad)      !! ~           !! F31
+105 !! 9 (Num-pad)      !! ~           !! F32
+106 !! 4 (Num-pad)      !! ~           !! F33
+107 !! 5 (Num-pad)      !! ~           !! F34
+108 !! 6 (Num-pad)      !! ~           !! F35
+109 !! 1 (Num-pad)      !! ~           !! F36
+110 !! 2 (Num-pad)      !! ~           !! F37
+111 !! 3 (Num-pad)      !! ~           !! F38
+112 !! 0 (Num-pad)      !! ~           !! F39
+113 !! . (Num-pad)      !! ~           !! F40
 114 !! Enter            !! ~           !! CTRL PRINT SCREEN
 115 !! Not present      !! Not present !! CTRL <--
 116 !! Not present      !! Not present !! CTRL -->
@@ -221,8 +221,8 @@ Scancode !! Deutschland !! USA !! Standard-VDI-Code
  37 !! K                !! K           !! K
  38 !! L                !! L           !! L
  39 !! ™                !! ;           !! ;
- 40 !! Ž                !! ,           !! ,
- 41 !! #                !! ~           !! ~
+ 40 !! Ž                !! '           !! '
+ 41 !! #                !! `           !! `
  42 !! Shift links      !! ~           !! ~
  43 !! ~                !! \           !! \
  44 !! Y                !! Z           !! Z
@@ -235,8 +235,8 @@ Scancode !! Deutschland !! USA !! Standard-VDI-Code
  51 !! ,                !! ,           !! ,
  52 !! .                !! .           !! .
  53 !! -                !! /           !! /
- 54 !! Shift rechts     !!             !! PRINT SCREEN
- 55 !! nicht vorh.      !! nicht vorh. !! ~
+ 54 !! Shift rechts     !! ~           !! ~
+ 55 !! nicht vorh.      !! nicht vorh. !! PRINT SCREEN
  56 !! Alternate        !! ~           !! ~
  57 !! Leertaste        !! ~           !! ~
  58 !! CapsLock         !! ~           !! ~


### PR DESCRIPTION
It seems that there were some misunderstandings when creating the table of scancodes.

Other sources ([Atari Profibuch ST/STE/TT](http://atariprofibuch.de) PDF page 1287, [keyboard layouts from Thorsten](http://tho-otto.de/keyboards/)) agree on the proposed changes.