### PR TITLE
Add ValidMode (aka VcheckMode)

### DIFF
--- a/xbios/bildscrm/bildscrm.u
+++ b/xbios/bildscrm/bildscrm.u
@@ -21,6 +21,7 @@
 !item [(!bullet) Setcolor]    Sets colour.
 !item [(!bullet) Setpalette]  Selects colour palette.
 !item [(!bullet) Setscreen]   Sets the current screen resolution and base addresses.
+!item [(!bullet) ValidMode]   Validates a mode code.
 !item [(!bullet) VgetRGB]     Gets RGB-value of a colour.
 !item [(!bullet) VsetScreen]  Sets the screen resolution and base addresses.
 !item [(!bullet) VgetSize]    Gets size of the screen buffer.
@@ -54,6 +55,7 @@
 !item [(!bullet) Setcolor]    Farbe einstellen.
 !item [(!bullet) Setpalette]  Farbpalette ausw(!aumlaut)hlen.
 !item [(!bullet) Setscreen]   Festlegen der Bildschirmaufl(!oumlaut)sung und -adressen.
+!item [(!bullet) ValidMode]   Validates a mode code.
 !item [(!bullet) VgetRGB]     RGB-Wert einer Farbe ermitteln.
 !item [(!bullet) VsetScreen]  Festlegen der Bildschirmaufl(!oumlaut)sung und -adressen
 !item [(!bullet) VgetSize]    Gr(!oumlaut)(!sharps)e des Bildschirmpuffers ermitteln.
@@ -86,6 +88,7 @@
 !include xbios/bildscrm/setscree.ui
 !include xbios/bildscrm/Setscreen_Milan.ui
 !include xbios/bildscrm/Setscreen_ct60.ui
+!include xbios/bildscrm/validmod.ui
 !include xbios/bildscrm/vgetrgb.ui
 !include xbios/bildscrm/vsetscre.ui
 !include xbios/bildscrm/vgetsize.ui

--- a/xbios/bildscrm/validmod.ui
+++ b/xbios/bildscrm/validmod.ui
@@ -45,7 +45,8 @@ Bit !! Meaning
 ~   !!          double-line mode (on VGA (!nolink [monitor])) active
 !end_table
 
-(!B)Note:(!b) This function is sometimes called Validmode or VcheckMode.
+(!B)Note:(!b) This function is not officially documented and some development
+tools may also call it Validmode or VcheckMode.
 
 !item [(!nolink [Return]) value:]
 The function returns a valid mode code.
@@ -127,7 +128,8 @@ Bit !! Bedeutung
 8   !! Gesetzt:  Interlace-Modus aktiv
 !end_table
 
-(!B)Note:(!b) This function is sometimes called Validmode or VcheckMode.
+(!B)Note:(!b) This function is not officially documented and some development
+tools may also call it Validmode or VcheckMode.
 
 !item [Ergebnis:]
 The function returns a valid mode code.

--- a/xbios/bildscrm/validmod.ui
+++ b/xbios/bildscrm/validmod.ui
@@ -1,0 +1,166 @@
+!iflang [english]
+
+
+!begin_node ValidMode
+#!html_name ValidMode
+!label VcheckMode
+
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!ldouble)ValidMode(!rdouble) - Validates a mode code.
+
+!item [Opcode:]
+95
+
+!item [Syntax:]
+int16_t ValidMode( int16_t mode );
+
+!item [Description:]
+The (!nolink [XBIOS]) function ValidMode returns a valid version of the
+specified mode code, depending on the (!nolink [monitor]) that is connected.
+The bits of the parameter (!I)mode(!i) have the following meaning:
+!begin_table [r|l]
+Bit !! Meaning
+!hline
+0-2 !! Number of colour planes: 
+~   !! 0 =  1 plane       2 colours
+~   !! 1 =  2 planes      4 colours
+~   !! 2 =  4 planes     16 colours
+~   !! 3 =  8 planes    256 colours
+~   !! 4 = 16 planes  65536 colours
+~   !! ~
+3   !! Set:     Image width at least 640 pixels (80 columns)
+~   !! Cleared: Image width 320 pixels (40 columns)
+~   !! ~
+4   !! Set:     VGA mode 
+~   !! Cleared: TV mode (also Atari SC monitors) 
+~   !! ~
+5   !! Set:     PAL mode 
+~   !! Cleared: NTSC mode 
+~   !! ~
+6   !! Set:     Overscan active (not valid for VGA)
+7   !! Set:     ST-compatible graphics
+8   !! Set:     Interlace mode (on colour (!nolink [monitor]) or 
+~   !!          double-line mode (on VGA (!nolink [monitor])) active
+!end_table
+
+(!B)Note:(!b) This function is sometimes called Validmode or VcheckMode.
+
+!item [(!nolink [Return]) value:]
+The function returns a valid mode code.
+
+!item [Availability:]
+The function is only available on computers of the Falcon series, Milan
+and CT60.
+
+!item [Group:]
+Screen functions
+
+!item [See also:]
+(!link [Binding] [Bindings for ValidMode]) ~ mon_type ~ VsetSync ~ VgetSize
+VgetRGB ~ VsetRGB ~ VsetMask ~ VsetMode
+
+(!ende_liste)
+
+!begin_node Bindings for ValidMode
+#!html_name Bindings_for_ValidMode
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int16_t ValidMode( int16_t mode );
+!item [Assembler:]
+!begin_verbatim
+move.w    mode,-(sp)    ; Offset 2
+move.w    #95,-(sp)     ; Offset 0
+trap      #14           ; Call XBIOS
+addq.l    #4,sp         ; Correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node ValidMode
+#!html_name ValidMode
+!label VcheckMode
+
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)ValidMode(!ldouble) - Validates a mode code.
+
+!item [Xbiosnummer:]
+95
+
+!item [Deklaration:]
+int16_t ValidMode( int16_t mode );
+
+!item [Beschreibung:]
+The (!nolink [XBIOS]) function ValidMode returns a valid version of the
+specified mode code, depending on the (!nolink [monitor]) that is connected.
+The bits of the parameter (!I)mode(!i) have the following meaning:
+!begin_table [r|l]
+Bit !! Bedeutung
+!hline
+0-2 !! Anzahl der Farbebenen:
+~   !! 0 = 1 Ebene       2 Farben
+~   !! 1 = 2 Ebenen      4 Farben
+~   !! 2 = 4 Ebenen     16 Farben
+~   !! 3 = 8 Ebenen    256 Farben
+~   !! 4 = 16 Ebenen 65536 Farben
+~   !! ~
+3   !! Gesetzt:  Bildbreite mindestens 640 Pixel
+~   !! Gel(!oumlaut)scht: Bildbreite 320 Pixel
+~   !! ~
+4   !! Gesetzt:  VGA-Modus
+~   !! Gel(!oumlaut)scht: TV-Modus (auch Atari-SC-Monitore)
+~   !! ~
+5   !! Gesetzt:  PAL-Modus
+~   !! Gel(!oumlaut)scht: NTSC-Modus
+~   !! ~
+6   !! Gesetzt:  Overscan aktiv
+7   !! Gesetzt:  ST-kompatible Grafik
+8   !! Gesetzt:  Interlace-Modus aktiv
+!end_table
+
+(!B)Note:(!b) This function is sometimes called Validmode or VcheckMode.
+
+!item [Ergebnis:]
+The function returns a valid mode code.
+
+!item [Verf(!uumlaut)gbar:]
+Die Funktion ist nur auf Computern der Falcon-Serie, Milan und CT60
+verf(!uumlaut)gbar.
+
+!item [Gruppe:]
+Bildschirmfunktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r ValidMode]) ~ mon_type ~ VsetSync ~ VgetSize
+VgetRGB ~ VsetRGB ~ VsetMask ~ VsetMode
+
+(!ende_liste)
+
+!begin_node Bindings f(!uumlaut)r ValidMode
+#!html_name Bindings_for_ValidMode
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int16_t ValidMode( int16_t mode );
+!item [Assembler:]
+!begin_verbatim
+move.w    mode,-(sp)    ; Offset 2
+move.w    #95,-(sp)     ; Offset 0
+trap      #14           ; XBIOS aufrufen
+addq.l    #4,sp         ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/xbios/xbios_f.u
+++ b/xbios/xbios_f.u
@@ -125,7 +125,7 @@ Dec !! Hex !! Name of function !! TOS !! others
 ~~92 !! 0x5C !!  VsetVars         !! Falcon-(!nolink [TOS])
 ~~93 !! 0x5D !!  VsetRGB          !! Falcon-(!nolink [TOS])
 ~~94 !! 0x5E !!  VgetRGB          !! Falcon-(!nolink [TOS])
-  95 !! 0x5F !!  VcheckMode       !! Falcon-(!nolink [TOS]), Milan(!nolink [TOS])
+  95 !! 0x5F !!  ValidMode / VcheckMode       !! Falcon-(!nolink [TOS]), Milan(!nolink [TOS])
 !hline
 ~~96 !! 0x60 !!  Dsp_DoBlock            !! Falcon-(!nolink [TOS])
 ~~97 !! 0x61 !!  Dsp_BlkHandShake       !! Falcon-(!nolink [TOS])
@@ -439,7 +439,7 @@ dez !! hex !! Funktionsname !! TOS !! Sonstiges
 ~~92 !! 0x5C !!  VsetVars         !! Falcon-(!nolink [TOS])
 ~~93 !! 0x5D !!  VsetRGB          !! Falcon-(!nolink [TOS])
 ~~94 !! 0x5E !!  VgetRGB          !! Falcon-(!nolink [TOS])
-  95 !! 0x5F !!  VcheckMode       !! Falcon-(!nolink [TOS]), Milan(!nolink [TOS])
+  95 !! 0x5F !!  ValidMode / VcheckMode       !! Falcon-(!nolink [TOS]), Milan(!nolink [TOS])
 !hline
 ~~96 !! 0x60 !!  Dsp_DoBlock            !! Falcon-(!nolink [TOS])
 ~~97 !! 0x61 !!  Dsp_BlkHandShake       !! Falcon-(!nolink [TOS])


### PR DESCRIPTION
The actual name is really ValidMode, see:
- [tos_drivers for CT60](https://github.com/ggnkua/Atari_ST_Sources/blob/47371756b9480b9a75088619bf77050cd4351a78/ASM/Various/Didier%20Mequignon/tos_drivers/drivers/detxbios.S#L539-L543)
- Sparrow video functions