### PR TITLE
gemdos network extension (part 2)

### DIFF
--- a/gemdos/gemdos_f.u
+++ b/gemdos/gemdos_f.u
@@ -79,7 +79,7 @@ dez !! hex !! Function !! present
  99 !! 0x62 !! End_Process  !! (!nolink [C'Task Royal])
  99 !! 0x63 !! Frunlock     !! 
  99 !! 0x63 !! Stop_Process !! (!nolink [C'Task Royal])
-100 !! 0x64 !! F_lock       !! 
+100 !! 0x64 !! (!link [Flock][F_lock])       !! 
 100 !! 0x64 !! Cont_Process !! (!nolink [C'Task Royal])
 100 !! 0x64 !! SetLinkAdr   !! TekBios
 101 !! 0x65 !! Funlock      !! 
@@ -429,7 +429,7 @@ dez !! hex !! Funktionsname !! vorhanden
  99 !! 0x62 !! End_Process  !! (!nolink [C'Task Royal])
  99 !! 0x63 !! Frunlock     !! 
  99 !! 0x63 !! Stop_Process !! (!nolink [C'Task Royal])
-100 !! 0x64 !! F_lock       !! 
+100 !! 0x64 !! (!link [Flock][F_lock])       !! 
 100 !! 0x64 !! Cont_Process !! (!nolink [C'Task Royal])
 100 !! 0x64 !! SetLinkAdr   !! TekBios
 101 !! 0x65 !! Funlock      !! 

--- a/gemdos/network/fflush.ui
+++ b/gemdos/network/fflush.ui
@@ -1,0 +1,112 @@
+# Source: TOS 91/9, S. 88
+
+!iflang [english]
+
+
+!begin_node Fflush
+#!html_name Fflush
+
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Fflush(!ldouble) - Flush the buffer of a file
+
+!item [Opcode:]
+102 (0x0066)
+
+!item [Syntax:]
+int32_t Fflush ( int16_t handle );
+
+!item [Description:]
+The (!nolink [GEMDOS]) routine Fflush writes all modified data of the
+specified file (!I)handle(!i) from its buffer to the disk.
+
+!item [(!nolink [Return]) value:]
+Returns E_OK on success, or a negative GEMDOS error code otherwise.
+
+!item [Availability:]
+Available when a network driver is (!nolink [installed]).
+
+!item [Group:]
+Network functions
+
+!item [See also:]
+(!link [Binding] [Bindings for Fflush])
+(!ende_liste)
+
+
+!begin_node Bindings for Fflush
+#!html_name Bindings_for_Fflush
+
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t Fflush ( int16_t handle );
+
+!item [Assembler:]
+!begin_verbatim
+move.w    handle,-(sp) ; Offset 2
+move.w    #102,-(sp)   ; Offset 0
+trap      #1           ; GEMDOS
+addq.l    #4,sp        ; correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node Fflush
+#!html_name Fflush
+
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Fflush(!ldouble) - Leert den Datenpuffer der Datei
+
+!item [Gemdosnummer:]
+102 (0x0066)
+
+!item [Deklaration:]
+int32_t Fflush ( int16_t handle );
+
+!item [Beschreibung:]
+Die Funktion leert den Datenpuffer der angegebenen Datei und schreibt die
+angesammelten Daten in die Datei.
+
+!item [Ergebnis:]
+Die Funktion liefert bei korrekter Ausf(!uumlaut)hrung eine 0, und eine negative
+Zahl, wenn es zu einem Fehler kam.
+
+!item [Verf(!uumlaut)gbar:]
+Verf(!uumlaut)gbar, wenn ein Netzwerktreiber installiert ist.
+
+!item [Gruppe:]
+Netzwerkfunktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r Fflush])
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r Fflush
+#!html_name Bindings_for_Fflush
+
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t Fflush ( int16_t handle );
+
+!item [Assembler:]
+!begin_verbatim
+move.w    handle,-(sp) ; Offset 2
+move.w    #102,-(sp)   ; Offset 0
+trap      #1           ; GEMDOS aufrufen
+addq.l    #2,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+!endif
+

--- a/gemdos/network/fflush.ui
+++ b/gemdos/network/fflush.ui
@@ -102,7 +102,7 @@ int32_t Fflush ( int16_t handle );
 move.w    handle,-(sp) ; Offset 2
 move.w    #102,-(sp)   ; Offset 0
 trap      #1           ; GEMDOS aufrufen
-addq.l    #2,sp        ; Stack korrigieren
+addq.l    #4,sp        ; Stack korrigieren
 !end_verbatim
 (!ende_liste)
 !end_node

--- a/gemdos/network/flock.ui
+++ b/gemdos/network/flock.ui
@@ -132,7 +132,7 @@ int32_t (!nolink [Flock]) ( int16_t handle, int32_t length );
 !begin_verbatim
 move.l    length,-(sp) ; Offset 4
 move.w    handle,-(sp) ; Offset 2
-move.w    #98,-(sp)    ; Offset 0
+move.w    #100,-(sp)   ; Offset 0
 trap      #1           ; GEMDOS aufrufen
 addq.l    #8,sp        ; Stack korrigieren
 !end_verbatim

--- a/gemdos/network/flock.ui
+++ b/gemdos/network/flock.ui
@@ -1,0 +1,144 @@
+# Source: TOS 91/9, S. 88
+
+!iflang [english]
+
+
+!begin_node F_lock
+#!html_name F_lock
+
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Flock(!ldouble) - Protect a portion of a file
+
+!item [Opcode:]
+100 (0x0064)
+
+!item [Syntax:]
+int32_t (!nolink [Flock]) ( int16_t handle, int32_t length );
+
+!item [Description:]
+The (!nolink [GEMDOS]) routine (!nolink [Flock]) serves to protect a portion of a file
+(from the current position) from access by other processes across a network.
+The following apply:
+
+!begin_xlist !compressed [Parameter]
+!item [Parameter]
+Meaning
+!item [~]
+~
+!item [handle]
+File ID
+!item [length]
+Number of bytes affected
+!end_xlist
+
+(!B)Note:(!b) Please do not confuse this function ($64) with Flock ($5C) from
+the specification for (!nolink [GEMDOS]) File Sharing & Record Locking.
+
+!item [(!nolink [Return]) value:]
+Returns E_OK on success, or a negative GEMDOS error code otherwise.
+
+!item [Availability:]
+Available when a network driver is (!nolink [installed]).
+
+!item [Group:]
+Network functions
+
+!item [See also:]
+(!link [Binding] [Bindings for F_lock]) Funlock
+(!ende_liste)
+
+
+!begin_node Bindings for F_lock
+#!html_name Bindings_for_F_lock
+
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t (!nolink [Flock]) ( int16_t handle, int32_t length );
+
+!item [Assembler:]
+!begin_verbatim
+move.l    length,-(sp) ; Offset 4
+move.w    handle,-(sp) ; Offset 2
+move.w    #100,-(sp)   ; Offset 0
+trap      #1           ; GEMDOS
+addq.l    #8,sp        ; correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node F_lock
+#!html_name F_lock
+
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Flock(!ldouble) - sch(!uumlaut)tzt Teile von Dateien
+
+!item [Gemdosnummer:]
+100 (0x0064)
+
+!item [Deklaration:]
+int32_t (!nolink[Flock]) ( int16_t handle, int32_t length );
+
+!item [Beschreibung:]
+Die (!nolink [GEMDOS])-Routine (!nolink[Flock]) dient dazu, Teile von Dateien (von der
+aktuellen position) gegen den Zugriff von anderen Prozessen zu sch(!uumlaut)tzen.
+Es gilt:
+
+!begin_xlist !compressed [Parameter]
+!item [Parameter]
+Bedeutung
+!item [~]
+~
+!item [handle]
+Dateikennung
+!item [start]
+Anzahl der betroffenen Bytes
+!end_xlist
+
+(!B)Hinweis:(!b) Verwechseln Sie diese Funktion ($64) nicht mit Flock ($5C) aus
+der Spezifikation f(!uumlaut)r (!nolink [GEMDOS]) File Sharing & Record Locking.
+
+!item [Ergebnis:]
+Die Funktion liefert bei korrekter Ausf(!uumlaut)hrung eine 0, und eine negative
+Zahl, wenn es zu einem Fehler kam.
+
+!item [Verf(!uumlaut)gbar:]
+Verf(!uumlaut)gbar, wenn ein Netzwerktreiber installiert ist.
+
+!item [Gruppe:]
+Netzwerkfunktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r F_lock]) Funlock
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r F_lock
+#!html_name Bindings_for_F_lock
+
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t (!nolink [Flock]) ( int16_t handle, int32_t length );
+
+!item [Assembler:]
+!begin_verbatim
+move.l    length,-(sp) ; Offset 4
+move.w    handle,-(sp) ; Offset 2
+move.w    #98,-(sp)    ; Offset 0
+trap      #1           ; GEMDOS aufrufen
+addq.l    #8,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+!endif
+

--- a/gemdos/network/funlock.ui
+++ b/gemdos/network/funlock.ui
@@ -1,0 +1,131 @@
+# Source: TOS 91/9, S. 88
+
+!iflang [english]
+
+
+!begin_node Funlock
+#!html_name Funlock
+
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Funlock(!ldouble) - Unlock a portion of a file
+
+!item [Opcode:]
+101 (0x0065)
+
+!item [Syntax:]
+int32_t Funlock ( int16_t handle );
+
+!item [Description:]
+The (!nolink [GEMDOS]) routine Funlock serves to unlock the portion of a file
+previously locked by (!link [Flock][F_lock]).
+The following apply:
+
+!begin_xlist !compressed [Parameter]
+!item [Parameter]
+Meaning
+!item [~]
+~
+!item [handle]
+File ID
+!end_xlist
+
+!item [(!nolink [Return]) value:]
+Returns E_OK on success, or a negative GEMDOS error code otherwise.
+
+!item [Availability:]
+Available when a network driver is (!nolink [installed]).
+
+!item [Group:]
+Network functions
+
+!item [See also:]
+(!link [Binding] [Bindings for Funlock]) (!link [Flock][F_lock])
+(!ende_liste)
+
+
+!begin_node Bindings for Funlock
+#!html_name Bindings_for_Funlock
+
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t Funlock ( int16_t handle );
+
+!item [Assembler:]
+!begin_verbatim
+move.w    handle,-(sp) ; Offset 2
+move.w    #101,-(sp)   ; Offset 0
+trap      #1           ; GEMDOS
+addq.l    #4,sp        ; correct stack
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node Funlock
+#!html_name Funlock
+
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Funlock(!ldouble) - entsch(!uumlaut)tzt Teile von Dateien
+
+!item [Gemdosnummer:]
+101 (0x0065)
+
+!item [Deklaration:]
+int32_t Funlock ( int16_t handle );
+
+!item [Beschreibung:]
+Die (!nolink [GEMDOS])-Routine Funlock hebt von (!link [Flock][F_lock])
+gesetzte Sperre wieder auf. Es gilt:
+
+!begin_xlist !compressed [Parameter]
+!item [Parameter]
+Bedeutung
+!item [~]
+~
+!item [handle]
+Dateikennung
+!end_xlist
+
+!item [Ergebnis:]
+Die Funktion liefert bei korrekter Ausf(!uumlaut)hrung eine 0, und eine negative
+Zahl, wenn es zu einem Fehler kam.
+
+!item [Verf(!uumlaut)gbar:]
+Verf(!uumlaut)gbar, wenn ein Netzwerktreiber installiert ist.
+
+!item [Gruppe:]
+Netzwerkfunktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r Funlock]) (!link [Flock][F_lock])
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r Funlock
+#!html_name Bindings_for_Funlock
+
+!ignore_index
+(!begin_liste) [Assembler:]
+!item [C:]
+int32_t Funlock ( int16_t handle );
+
+!item [Assembler:]
+!begin_verbatim
+move.w    handle,-(sp) ; Offset 2
+move.w    #101,-(sp)   ; Offset 0
+trap      #1           ; GEMDOS aufrufen
+addq.l    #4,sp        ; Stack korrigieren
+!end_verbatim
+(!ende_liste)
+!end_node
+!end_node
+
+!endif
+

--- a/gemdos/network/network.u
+++ b/gemdos/network/network.u
@@ -5,8 +5,11 @@
 !html_name gemdos_network
 
 !begin_xlist [x Nversion] !compressed
+!item [(!bullet) Fflush] Flush file
+!item [(!bullet) (!link [Flock][F_lock])] Lock file from current position
 !item [(!bullet) Frlock] Lock a file record
 !item [(!bullet) Frunlock] Unlock a file record
+!item [(!bullet) Funlock] Unlock file
 !item [(!bullet) Nversion] Network identifier determine
 !end_xlist
 
@@ -18,8 +21,11 @@
 !html_name gemdos_network
 
 !begin_xlist [x Nversion] !compressed
+!item [(!bullet) Fflush] Datenpuffer einer Datei leeren
+!item [(!bullet) (!link [Flock][F_lock])] Datei von aktuelle Position sperren
 !item [(!bullet) Frlock] File Record sperren
 !item [(!bullet) Frunlock] File record freigeben
+!item [(!bullet) Funlock] File freigeben
 !item [(!bullet) Nversion] Kennung des Netzwerkes
 !end_xlist
 
@@ -27,8 +33,11 @@
 !endif
 
 
+!include gemdos/network/fflush.ui
+!include gemdos/network/flock.ui
 !include gemdos/network/frlock.ui
 !include gemdos/network/frunlock.ui
+!include gemdos/network/funlock.ui
 !include gemdos/network/Nversion.ui
 
 !end_node


### PR DESCRIPTION
Add Flock/Funlock/Fflush

Source:
https://www.stcarchiv.de/tos1991/09/gemdos-teil-3

Still missing: Lock/Unlock. According to the above source, Lock=gemdos(123) , Unlock=gemdos(124). 

It seems to be wrong, the following sources indicate Unlock=123 and Lock=124 (what looks like Nunlock/Nlock by PAM's NET):
- [ST-Magazin 1989/11](http://www.homecomputerworld.at/magazine/st-magazin/st_magazin_1989-11.pdf#page=64)
- [ADEBUG Reloaded](https://github.com/ggnkua/Atari_ST_Sources/blob/47371756b9480b9a75088619bf77050cd4351a78/ASM/Brainstorm/Adebug%20Reloaded%20v2.13/src/disasmxx.s#L1832-L1839)
- [CENTinel](https://github.com/ggnkua/Atari_ST_Sources/blob/47371756b9480b9a75088619bf77050cd4351a78/ASM/Various/Ronan%20Cardaut/40/MAIN.INC/FONCTION.S#L767-L781)
