### PR TITLE
Add VDI sound functions

### DIFF
--- a/gem/vdi/escape/escape.u
+++ b/gem/vdi/escape/escape.u
@@ -12,6 +12,7 @@ are available:
 !item Graphics tablet functions
 !item Metafile functions
 !item Polaroid functions
+!item Sound functions
 !item Special functions
 !item Text functions
 !end_itemize
@@ -33,6 +34,7 @@ Funktionsgruppen zur Verf(!uumlaut)gung:
 !item Grafiktablett-Funktionen
 !item Metafile-Funktionen
 !item Polaroid-Funktionen
+!item Sound-Funktionen
 !item Spezialfunktionen
 !item Text-Funktionen
 !end_itemize
@@ -46,6 +48,7 @@ Workstations des VDI ~ Style-Guidelines
 !include gem/vdi/escape/tablet/tablet.u
 !include gem/vdi/escape/metafile/metafile.u
 !include gem/vdi/escape/camera/camera.u
+!include gem/vdi/escape/sound/sound.u
 !include gem/vdi/escape/special/special.u
 !include gem/vdi/escape/text/text.u
 

--- a/gem/vdi/escape/sound/sound.u
+++ b/gem/vdi/escape/sound/sound.u
@@ -1,0 +1,148 @@
+!iflang [english]
+
+!begin_node Sound functions
+
+This library contains functions for audio playback through supported sound
+system; the following routines are available for this purpose:
+
+!begin_xlist !compressed [x vqspl_time_left_d2d]
+!item [(!bullet) vmid_load]
+Loads a MIDI file
+!item [(!bullet) vmid_play]
+Plays a MIDI file
+!item [(!bullet) vmid_unload]
+Releases memory occupied by a MIDI file
+!item [(!bullet) vqspl_position_d2d]
+Gets current position when playing through D2D
+!item [(!bullet) vqspl_position_dma]
+Gets current position when playing through DMA
+!item [(!bullet) vqspl_status_d2d]
+Gets current D2D status
+!item [(!bullet) vqspl_status_dma]
+Gets current DMA status
+!item [(!bullet) vqspl_time_left_d2d]
+Gets remaining time when playing through D2D
+!item [(!bullet) vspl_load_d2d]
+Loads an audio file for playing through D2D
+!item [(!bullet) vspl_load_sample]
+Loads a sample for DMA playback
+!item [(!bullet) vspl_make_d2d]
+Continues D2D playback
+!item [(!bullet) vspl_pause_d2d]
+Suspends D2D playback
+!item [(!bullet) vspl_pause_dma]
+Suspends DMA playback
+!item [(!bullet) vspl_play]
+Plays an audio file
+!item [(!bullet) vspl_play_d2d]
+Starts playback of an audio file through D2D
+!item [(!bullet) vspl_play_dma]
+Plays a sample through DMA
+!item [(!bullet) vspl_stop_d2d]
+Stops D2D playback
+!item [(!bullet) vspl_stop_dma]
+Stops DMA playback
+!item [(!bullet) vspl_unload_d2d]
+Releases memory allocated for the D2D playback
+!item [(!bullet) vspl_unload_sample]
+Releases memory occupied by a sample
+!item [(!bullet) vsspl_monitor_off]
+Disables monitoring
+!item [(!bullet) vsspl_monitor_on]
+Enables monitoring
+!end_xlist
+
+(!B)Note:(!b) Currently the unit of time for the start (!I)position(!i) and for
+the returned remaining time is unknown. The purpose of monitoring is also
+unknown.
+
+See also:
+VDI workstations ~ Style guidelines
+
+!else
+
+!begin_node Sound-Funktionen
+
+This library contains functions for audio playback through supported sound
+system; the following routines are available for this purpose:
+
+!begin_xlist !compressed [x vqspl_time_left_d2d]
+!item [(!bullet) vmid_load]
+Loads a MIDI file
+!item [(!bullet) vmid_play]
+Plays a MIDI file
+!item [(!bullet) vmid_unload]
+Releases memory occupied by a MIDI file
+!item [(!bullet) vqspl_position_d2d]
+Gets current position when playing through D2D
+!item [(!bullet) vqspl_position_dma]
+Gets current position when playing through DMA
+!item [(!bullet) vqspl_status_d2d]
+Gets current D2D status
+!item [(!bullet) vqspl_status_dma]
+Gets current DMA status
+!item [(!bullet) vqspl_time_left_d2d]
+Gets remaining time when playing through D2D
+!item [(!bullet) vspl_load_d2d]
+Loads an audio file for playing through D2D
+!item [(!bullet) vspl_load_sample]
+Loads a sample for DMA playback
+!item [(!bullet) vspl_make_d2d]
+Continues D2D playback
+!item [(!bullet) vspl_pause_d2d]
+Suspends D2D playback
+!item [(!bullet) vspl_pause_dma]
+Suspends DMA playback
+!item [(!bullet) vspl_play]
+Plays an audio file
+!item [(!bullet) vspl_play_d2d]
+Starts playback of an audio file through D2D
+!item [(!bullet) vspl_play_dma]
+Plays a sample through DMA
+!item [(!bullet) vspl_stop_d2d]
+Stops D2D playback
+!item [(!bullet) vspl_stop_dma]
+Stops DMA playback
+!item [(!bullet) vspl_unload_d2d]
+Releases memory allocated for the D2D playback
+!item [(!bullet) vspl_unload_sample]
+Releases memory occupied by a sample
+!item [(!bullet) vsspl_monitor_off]
+Disables monitoring
+!item [(!bullet) vsspl_monitor_on]
+Enables monitoring
+!end_xlist
+
+(!B)Note:(!b) Currently the unit of time for the start (!I)position(!i) and for
+the returned remaining time is unknown. The purpose of monitoring is also
+unknown.
+
+Querverweis:
+Workstations des VDI ~ Style-Guidelines
+
+!endif
+
+!include gem/vdi/escape/sound/vmid_load.ui
+!include gem/vdi/escape/sound/vmid_play.ui
+!include gem/vdi/escape/sound/vmid_unload.ui
+!include gem/vdi/escape/sound/vqspl_position_d2d.ui
+!include gem/vdi/escape/sound/vqspl_position_dma.ui
+!include gem/vdi/escape/sound/vqspl_status_d2d.ui
+!include gem/vdi/escape/sound/vqspl_status_dma.ui
+!include gem/vdi/escape/sound/vqspl_time_left_d2d.ui
+!include gem/vdi/escape/sound/vspl_load_d2d.ui
+!include gem/vdi/escape/sound/vspl_load_sample.ui
+!include gem/vdi/escape/sound/vspl_make_d2d.ui
+!include gem/vdi/escape/sound/vspl_pause_d2d.ui
+!include gem/vdi/escape/sound/vspl_pause_dma.ui
+!include gem/vdi/escape/sound/vspl_play.ui
+!include gem/vdi/escape/sound/vspl_play_d2d.ui
+!include gem/vdi/escape/sound/vspl_play_dma.ui
+!include gem/vdi/escape/sound/vspl_stop_d2d.ui
+!include gem/vdi/escape/sound/vspl_stop_dma.ui
+!include gem/vdi/escape/sound/vspl_unload_d2d.ui
+!include gem/vdi/escape/sound/vspl_unload_sample.ui
+!include gem/vdi/escape/sound/vsspl_monitor_off.ui
+!include gem/vdi/escape/sound/vsspl_monitor_on.ui
+
+!end_node

--- a/gem/vdi/escape/sound/vmid_load.ui
+++ b/gem/vdi/escape/sound/vmid_load.ui
@@ -1,0 +1,167 @@
+!iflang [english]
+
+
+!begin_node vmid_load
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Load Midifile(!ldouble) - Loads a MIDI file
+
+!item [Opcode:]
+5 (Escape 4000)
+
+!item [Syntax:]
+int16_t vmid_load( int16_t handle, int8_t *fname, uint32_t position );
+
+!item [Description:]
+The call vmid_load loads the MIDI file (!I)fname(!i) from the position
+(!I)position(!i) into memory.
+
+!item [(!nolink [Return]) value:]
+An error has arisen only if the value 0 is returned.
+
+!item [Availability:]
+SpeedoGDOS with MIDI sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vmid_load]) ~ vmid_play ~ vmid_unload
+
+(!ende_liste)
+
+
+!begin_node Bindings for vmid_load
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vmid_load( int16_t handle, int8_t *fname, uint32_t position );
+!item [Binding:]
+!begin_verbatim
+int16_t vmid_load (int16_t handle, int8_t *fname, uint32_t position)
+{
+   int16_t tmp;
+
+   intin[0..1] = position;
+
+   tmp = 2;
+   while (intin[tmp++] = *fname++)
+      ;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = --tmp;
+   contrl[5] = 4000;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0]     !! 5     # Function opcode
+contrl+2  !! contrl[1]     !! 0     # Entry in ptsin
+contrl+4  !! contrl[2]     !! 0     # Entry in ptsout
+contrl+6  !! contrl[3]     !! n     # Entry in intin
+contrl+8  !! contrl[4]     !! 1     # Entry in intout
+contrl+10 !! contrl[5]     !! 4000  # Escape/Sub-opcode
+contrl+12 !! contrl[6]     !! handle
+intin     !! intin[0..1]   !! position
+intin+4   !! intin[2..n-1] !! fname
+intout    !! intout[0]     !! Return value
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vmid_load
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Load Midifile(!ldouble) - Loads a MIDI file
+
+!item [VDI-Nummer:]
+5 (4000)
+
+!item [Deklaration:]
+int16_t vmid_load( int16_t handle, int8_t *fname, uint32_t position );
+
+!item [Beschreibung:]
+The call vmid_load loads the MIDI file (!I)fname(!i) from the position
+(!I)position(!i) into memory.
+
+!item [Ergebnis:]
+An error has arisen only if the value 0 is returned.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit MIDI-Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vmid_load]) ~ vmid_play ~ vmid_unload
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vmid_load
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vmid_load( int16_t handle, int8_t *fname, uint32_t position );
+!item [Umsetzung:]
+!begin_verbatim
+int16_t vmid_load(int16_t handle, int8_t *fname, uint32_t position)
+{
+   int16_t tmp;
+
+   intin[0..1] = position;
+
+   tmp = 2;
+   while (intin[tmp++] = *fname++)
+      ;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = --tmp;
+   contrl[5] = 4000;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0]     !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1]     !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2]     !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3]     !! n     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4]     !! 1     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5]     !! 4000  # Escape/Sub-opcode
+contrl+12 !! contrl[6]     !! handle
+intin     !! intin[0..1]   !! position
+intin+4   !! intin[2..n-1] !! fname
+intout    !! intout[0]     !! (!nolink [Return])-Wert
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vmid_play.ui
+++ b/gem/vdi/escape/sound/vmid_play.ui
@@ -1,0 +1,141 @@
+!iflang [english]
+
+
+!begin_node vmid_play
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Play Midifile(!ldouble) - Replay a MIDI file
+
+!item [Opcode:]
+5 (Escape 4002)
+
+!item [Syntax:]
+void vmid_play( int16_t handle );
+
+!item [Description:]
+The call vmid_play starts the playback of a MIDI file loaded previously with
+vmid_load.
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with a sound driver that supports MIDI files.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vmid_play]) ~ vmid_load ~ vmid_unload
+
+(!ende_liste)
+
+
+!begin_node Bindings for vmid_play
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vmid_play( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+void vmid_play (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 4002;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 0     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 4002  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vmid_play
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Play Midifile(!ldouble) - Replay a MIDI file
+
+!item [VDI-Nummer:]
+5 (4002)
+
+!item [Deklaration:]
+void vmid_play( int16_t handle );
+
+!item [Beschreibung:]
+The call vmid_play starts the playback of a MIDI file loaded previously with
+vmid_load.
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit MIDI-Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vmid_play]) ~ vmid_load ~ vmid_unload
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vmid_play
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vmid_play( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+void vmid_play(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 4002;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 4002  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vmid_unload.ui
+++ b/gem/vdi/escape/sound/vmid_unload.ui
@@ -1,0 +1,139 @@
+!iflang [english]
+
+
+!begin_node vmid_unload
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Unload Midifile(!ldouble) - Unload a MIDI file
+
+!item [Opcode:]
+5 (Escape 4001)
+
+!item [Syntax:]
+void vmid_unload( int16_t handle );
+
+!item [Description:]
+The call vmid_unload releases the memory allocated for MIDI playback.
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with a sound driver that supports MIDI files.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vmid_unload]) ~ vmid_load ~ vmid_play
+
+(!ende_liste)
+
+
+!begin_node Bindings for vmid_unload
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vmid_unload( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+void vmid_unload (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 4001;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 0     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 4001  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vmid_unload
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Unload Midifile(!ldouble) - Unload a MIDI file
+
+!item [VDI-Nummer:]
+5 (4001)
+
+!item [Deklaration:]
+void vmid_unload( int16_t handle );
+
+!item [Beschreibung:]
+The call vmid_unload releases the memory allocated for MIDI playback.
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit MIDI-Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vmid_unload]) ~ vmid_load ~ vmid_play
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vmid_unload
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vmid_unload( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+void vmid_unload(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 4001;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 4001  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vqspl_position_d2d.ui
+++ b/gem/vdi/escape/sound/vqspl_position_d2d.ui
@@ -1,0 +1,151 @@
+!iflang [english]
+
+
+!begin_node vqspl_position_d2d
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Inquire D2D position(!ldouble) - Gets the current D2D playback position
+
+!item [Opcode:]
+5 (Escape 3017)
+
+!item [Syntax:]
+uint32_t vqspl_position_d2d( int16_t handle );
+
+!item [Description:]
+The call vqspl_position_d2d returns the current position of the audio file
+being played through D2D.
+
+!item [(!nolink [Return]) value:]
+This function returns the current position.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vqspl_position_d2d]) ~ vqspl_status_d2d ~
+vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~ vspl_pause_d2d ~
+vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings for vqspl_position_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+uint32_t vqspl_position_d2d( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+uint32_t vqspl_position_d2d (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3017;
+   contrl[6] = handle;
+
+   vdi();
+
+   return intout[0..1];
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0]    !! 5     # Function opcode
+contrl+2  !! contrl[1]    !! 0     # Entry in ptsin
+contrl+4  !! contrl[2]    !! 0     # Entry in ptsout
+contrl+6  !! contrl[3]    !! 0     # Entry in intin
+contrl+8  !! contrl[4]    !! 2     # Entry in intout
+contrl+10 !! contrl[5]    !! 3017  # Escape/Sub-opcode
+contrl+12 !! contrl[6]    !! handle
+intout    !! intout[0..1] !! Return value
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vqspl_position_d2d
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Inquire D2D position(!ldouble) - Gets the current D2D playback position
+
+!item [VDI-Nummer:]
+5 (3017)
+
+!item [Deklaration:]
+uint32_t vqspl_position_d2d( int16_t handle );
+
+!item [Beschreibung:]
+The call vqspl_position_d2d returns the current position of the audio file
+being played through D2D.
+
+!item [Ergebnis:]
+Die Funktion liefert die aktuelle Position.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vqspl_position_d2d]) ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_pause_d2d ~ vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vqspl_position_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+uint32_t vqspl_position_d2d( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+uint32_t vqspl_position_d2d(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3017;
+   contrl[6] = handle;
+
+   vdi();
+
+   return intout[0..1];
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0]    !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1]    !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2]    !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3]    !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4]    !! 2     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5]    !! 3017  # Escape/Sub-opcode
+contrl+12 !! contrl[6]    !! handle
+intout    !! intout[0..1] !! (!nolink [Return])-Wert
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vqspl_position_dma.ui
+++ b/gem/vdi/escape/sound/vqspl_position_dma.ui
@@ -1,0 +1,157 @@
+!iflang [english]
+
+
+!begin_node vqspl_position_dma
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Inquire DMA position(!ldouble) - Gets the DMA position
+
+!item [Opcode:]
+5 (Escape 3006)
+
+!item [Syntax:]
+uint32_t vqspl_position_dma( int16_t handle, int16_t id );
+
+!item [Description:]
+The call vqspl_position_dma obtains the current DMA playback position for the
+sample identified by (!I)id(!i).
+
+!item [(!nolink [Return]) value:]
+This function returns the sample DMA position.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vqspl_position_dma]) ~ vqspl_status_dma ~
+vspl_load_sample ~ vspl_pause_dma ~ vspl_play_dma ~ vspl_stop_dma ~
+vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings for vqspl_position_dma
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+uint32_t vqspl_position_dma( int16_t handle, int16_t id );
+!item [Binding:]
+!begin_verbatim
+uint32_t vqspl_position_dma (int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3006;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0..1] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0]    !! 5     # Function opcode
+contrl+2  !! contrl[1]    !! 0     # Entry in ptsin
+contrl+4  !! contrl[2]    !! 0     # Entry in ptsout
+contrl+6  !! contrl[3]    !! 1     # Entry in intin
+contrl+8  !! contrl[4]    !! 2     # Entry in intout
+contrl+10 !! contrl[5]    !! 3006  # Escape/Sub-opcode
+contrl+12 !! contrl[6]    !! handle
+intin     !! intin[0]     !! id
+intout    !! intout[0..1] !! Return value
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vqspl_position_dma
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Inquire DMA position(!ldouble) - Gets the DMA position
+
+!item [VDI-Nummer:]
+5 (3006)
+
+!item [Deklaration:]
+uint32_t vqspl_position_dma( int16_t handle, int16_t id );
+
+!item [Beschreibung:]
+The call vqspl_position_dma obtains the current sample DMA position for the
+sample identified by (!I)id(!i).
+
+!item [Ergebnis:]
+This function returns the sample DMA position.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vqspl_position_dma]) ~
+vqspl_status_dma ~ vspl_load_sample ~ vspl_pause_dma ~ vspl_play_dma ~
+vspl_stop_dma ~ vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vqspl_position_dma
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+uint32_t vqspl_position_dma( int16_t handle, int16_t id );
+!item [Umsetzung:]
+!begin_verbatim
+uint32_t vqspl_position_dma(int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3006;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0..1] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0]    !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1]    !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2]    !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3]    !! 1     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4]    !! 2     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5]    !! 3006  # Escape/Sub-opcode
+contrl+12 !! contrl[6]    !! handle
+intin     !! intin[0]     !! id
+intout    !! intout[0..1] !! (!nolink [Return])-Werte
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vqspl_status_d2d.ui
+++ b/gem/vdi/escape/sound/vqspl_status_d2d.ui
@@ -1,0 +1,151 @@
+!iflang [english]
+
+
+!begin_node vqspl_status_d2d
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Inquire D2D status(!ldouble) - Gets the current status of the D2D audio system
+
+!item [Opcode:]
+5 (Escape 3016)
+
+!item [Syntax:]
+int16_t vqspl_status_d2d( int16_t handle );
+
+!item [Description:]
+The call vqspl_status_d2d returns the current status of the D2D audio system.
+
+!item [(!nolink [Return]) value:]
+This function returns the current status. If nonzero, the D2D audio system is
+ready to process the next audio data from disk through a call to vspl_make_d2d.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vqspl_status_d2d]) ~ vqspl_position_d2d ~
+vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~ vspl_pause_d2d ~
+vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings for vqspl_status_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vqspl_status_d2d( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+int16_t vqspl_status_d2d (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3016;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0]    !! 5     # Function opcode
+contrl+2  !! contrl[1]    !! 0     # Entry in ptsin
+contrl+4  !! contrl[2]    !! 0     # Entry in ptsout
+contrl+6  !! contrl[3]    !! 0     # Entry in intin
+contrl+8  !! contrl[4]    !! 1     # Entry in intout
+contrl+10 !! contrl[5]    !! 3016  # Escape/Sub-opcode
+contrl+12 !! contrl[6]    !! handle
+intout    !! intout[0]    !! Return value
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vqspl_status_d2d
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Inquire D2D status(!ldouble) - Gets the current status of the D2D audio system
+
+!item [VDI-Nummer:]
+5 (3016)
+
+!item [Deklaration:]
+int16_t vqspl_status_d2d( int16_t handle );
+
+!item [Beschreibung:]
+The call vqspl_status_d2d returns the current status of the D2D audio system.
+
+!item [Ergebnis:]
+Die Funktion liefert die aktuelle Status. If nonzero, the D2D audio system is
+ready to process the next audio data from disk through a call to vspl_make_d2d.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vqspl_status_d2d]) ~
+vqspl_position_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_pause_d2d ~ vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vqspl_status_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vqspl_status_d2d( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+int16_t vqspl_status_d2d(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3016;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0]    !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1]    !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2]    !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3]    !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4]    !! 1     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5]    !! 3016  # Escape/Sub-opcode
+contrl+12 !! contrl[6]    !! handle
+intout    !! intout[0]    !! (!nolink [Return])-Wert
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vqspl_status_dma.ui
+++ b/gem/vdi/escape/sound/vqspl_status_dma.ui
@@ -1,0 +1,159 @@
+!iflang [english]
+
+
+!begin_node vqspl_status_dma
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Inquire DMA status(!ldouble) - Gets the current DMA status
+
+!item [Opcode:]
+5 (Escape 3005)
+
+!item [Syntax:]
+int16_t vqspl_status_dma( int16_t handle, int16_t id );
+
+!item [Description:]
+The call vqspl_status_dma obtains the current DMA playback status for the
+sample identified by (!I)id(!i).
+
+!item [(!nolink [Return]) value:]
+This function returns the sample DMA status (sound currently playing if
+bit 0 = 1).
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vqspl_status_dma]) ~ vqspl_position_dma ~
+vspl_load_sample ~ vspl_pause_dma ~ vspl_play_dma ~ vspl_stop_dma ~
+vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings for vqspl_status_dma
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vqspl_status_dma( int16_t handle, int16_t id );
+!item [Binding:]
+!begin_verbatim
+int16_t vqspl_status_dma (int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3005;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 1     # Entry in intin
+contrl+8  !! contrl[4] !! 1     # Entry in intout
+contrl+10 !! contrl[5] !! 3005  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+intin     !! intin[0]  !! id
+intout    !! intout[0] !! Return value
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vqspl_status_dma
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Inquire DMA status(!ldouble) - Gets the current DMA status
+
+!item [VDI-Nummer:]
+5 (3005)
+
+!item [Deklaration:]
+int16_t vqspl_status_dma( int16_t handle, int16_t id );
+
+!item [Beschreibung:]
+The call vqspl_status_dma obtains the current sample DMA status for the sample
+identified by (!I)id(!i).
+
+!item [Ergebnis:]
+This function returns the sample DMA status (sound currently playing if
+bit 0 = 1).
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vqspl_status_dma]) ~
+vqspl_position_dma ~ vspl_load_sample ~ vspl_pause_dma ~ vspl_play_dma ~
+vspl_stop_dma ~ vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vqspl_status_dma
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vqspl_status_dma( int16_t handle, int16_t id );
+!item [Umsetzung:]
+!begin_verbatim
+int16_t vqspl_status_dma(int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3005;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 1     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 1     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3005  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+intin     !! intin[0]  !! id
+intout    !! intout[0] !! (!nolink [Return])-Wert
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vqspl_time_left_d2d.ui
+++ b/gem/vdi/escape/sound/vqspl_time_left_d2d.ui
@@ -1,0 +1,151 @@
+!iflang [english]
+
+
+!begin_node vqspl_time_left_d2d
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Inquire D2D remaining time(!ldouble) - Gets the D2D remaining playing time
+
+!item [Opcode:]
+5 (Escape 3018)
+
+!item [Syntax:]
+int16_t vqspl_time_left_d2d( int16_t handle );
+
+!item [Description:]
+The call vqspl_time_left_d2d returns the remaining playing time on the D2D
+audio system.
+
+!item [(!nolink [Return]) value:]
+This function returns the remaining playing time.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vqspl_time_left_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~ vspl_pause_d2d ~
+vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings for vqspl_time_left_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vqspl_time_left_d2d( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+int16_t vqspl_time_left_d2d (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3018;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0]    !! 5     # Function opcode
+contrl+2  !! contrl[1]    !! 0     # Entry in ptsin
+contrl+4  !! contrl[2]    !! 0     # Entry in ptsout
+contrl+6  !! contrl[3]    !! 0     # Entry in intin
+contrl+8  !! contrl[4]    !! 1     # Entry in intout
+contrl+10 !! contrl[5]    !! 3018  # Escape/Sub-opcode
+contrl+12 !! contrl[6]    !! handle
+intout    !! intout[0]   !! Return value
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vqspl_time_left_d2d
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)vqspl_time_left_d2d(!ldouble) - Gets the D2D remaining playing time
+
+!item [VDI-Nummer:]
+5 (3018)
+
+!item [Deklaration:]
+int16_t vqspl_time_left_d2( int16_t handle );
+
+!item [Beschreibung:]
+The call vqspl_time_left_d2d returns the remaining playing time on the D2D
+audio system.
+
+!item [Ergebnis:]
+This function returns the remaining playing time.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vqspl_time_left_d2d]) ~
+vqspl_position_d2d ~ vqspl_status_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_pause_d2d ~ vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vqspl_time_left_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vqspl_time_left_d2d( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+int16_t vqspl_time_left_d2d(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3018;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0]    !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1]    !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2]    !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3]    !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4]    !! 1     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5]    !! 3018  # Escape/Sub-opcode
+contrl+12 !! contrl[6]    !! handle
+intout    !! intout[0]    !! Return-Wert
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_load_d2d.ui
+++ b/gem/vdi/escape/sound/vspl_load_d2d.ui
@@ -1,0 +1,171 @@
+!iflang [english]
+
+
+!begin_node vspl_load_d2d
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Prepare D2D playback(!ldouble) - Loads an audio file
+
+!item [Opcode:]
+5 (Escape 3011)
+
+!item [Syntax:]
+int16_t vspl_load_d2d( int16_t handle, int8_t *fname, uint32_t position );
+
+!item [Description:]
+The call vspl_load_d2d loads the file (!I)fname(!i) from the position
+(!I)position(!i) into memory for D2D playback.
+
+!item [(!nolink [Return]) value:]
+An error has arisen only if the value 0 is returned.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_load_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_make_d2d ~ vspl_pause_d2d ~
+vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_load_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vspl_load_d2d( int16_t handle, int8_t *fname, uint32_t position );
+!item [Binding:]
+!begin_verbatim
+int16_t vspl_load_d2d (int16_t handle, int8_t *fname, uint32_t position)
+{
+   int16_t tmp;
+
+   intin[0..1] = position;
+
+   tmp = 2;
+   while (intin[tmp++] = *fname++)
+      ;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = --tmp;
+   contrl[5] = 3011;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0]     !! 5     # Function opcode
+contrl+2  !! contrl[1]     !! 0     # Entry in ptsin
+contrl+4  !! contrl[2]     !! 0     # Entry in ptsout
+contrl+6  !! contrl[3]     !! n     # Entry in intin
+contrl+8  !! contrl[4]     !! 1     # Entry in intout
+contrl+10 !! contrl[5]     !! 3011  # Escape/Sub-opcode
+contrl+12 !! contrl[6]     !! handle
+intin     !! intin[0..1]   !! position
+intin+4   !! intin[2..n-1] !! fname
+intout    !! intout[0]     !! Return value
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_load_d2d
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Prepare D2D playback(!ldouble) - Loads an audio file
+
+!item [VDI-Nummer:]
+5 (3011)
+
+!item [Deklaration:]
+int16_t vspl_load_d2d( int16_t handle, int8_t *fname, uint32_t position );
+
+!item [Beschreibung:]
+The call vspl_load_d2d loads the file (!I)fname(!i) from the position
+(!I)position(!i) into memory for D2D playback.
+
+!item [Ergebnis:]
+An error has arisen only if the value 0 is returned.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_load_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_make_d2d ~ vspl_pause_d2d ~
+vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_load_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vspl_load_d2d( int16_t handle, int8_t *fname, uint32_t position );
+!item [Umsetzung:]
+!begin_verbatim
+int16_t vspl_load_d2d(int16_t handle, int8_t *fname, uint32_t position)
+{
+   int16_t tmp;
+
+   intin[0..1] = position;
+
+   tmp = 2;
+   while (intin[tmp++] = *fname++)
+      ;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = --tmp;
+   contrl[5] = 3011;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0]     !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1]     !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2]     !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3]     !! n     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4]     !! 1     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5]     !! 3011  # Escape/Sub-opcode
+contrl+12 !! contrl[6]     !! handle
+intin     !! intin[0..1]   !! position
+intin+4   !! intin[2..n-1] !! fname
+intout    !! intout[0]     !! (!nolink [Return])-Wert
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_load_sample.ui
+++ b/gem/vdi/escape/sound/vspl_load_sample.ui
@@ -1,0 +1,173 @@
+!iflang [english]
+
+
+!begin_node vspl_load_sample
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Load sample(!ldouble) - Loads an audio file
+
+!item [Opcode:]
+5 (Escape 3001)
+
+!item [Syntax:]
+int16_t vspl_load_sample( int16_t handle, int8_t *fname, uint32_t position );
+
+!item [Description:]
+The call vspl_load_sample loads the file (!I)fname(!i) from the position
+(!I)position(!i) into memory. Multiple samples can be loaded into a single
+workstation, each sample is identified by an index.
+
+!item [(!nolink [Return]) value:]
+This function returns the corresponding sample index.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_load_sample]) ~ vqspl_position_dma ~
+vqspl_status_dma ~ vspl_pause_dma ~ vspl_play_dma ~ vspl_stop_dma ~
+vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_load_sample
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vspl_load_sample( int16_t handle, int8_t *fname, uint32_t position );
+!item [Binding:]
+!begin_verbatim
+int16_t vspl_load_sample (int16_t handle, int8_t *fname, uint32_t position)
+{
+   int16_t tmp;
+
+   intin[0..1] = position;
+
+   tmp = 2;
+   while (intin[tmp++] = *fname++)
+      ;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = --tmp;
+   contrl[5] = 3001;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0]     !! 5     # Function opcode
+contrl+2  !! contrl[1]     !! 0     # Entry in ptsin
+contrl+4  !! contrl[2]     !! 0     # Entry in ptsout
+contrl+6  !! contrl[3]     !! n     # Entry in intin
+contrl+8  !! contrl[4]     !! 1     # Entry in intout
+contrl+10 !! contrl[5]     !! 3001  # Escape/Sub-opcode
+contrl+12 !! contrl[6]     !! handle
+intin     !! intin[0..1]   !! position
+intin+4   !! intin[2..n-1] !! fname
+intout    !! intout[0]     !! Return value
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_load_sample
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Load sample(!ldouble) - Loads an audio file
+
+!item [VDI-Nummer:]
+5 (3001)
+
+!item [Deklaration:]
+int16_t vspl_load_sample( int16_t handle, int8_t *fname, uint32_t position );
+
+!item [Beschreibung:]
+The call vspl_load_sample loads the file (!I)fname(!i) from the position
+(!I)position(!i) into memory. Multiple samples can be loaded into a single
+workstation, each sample is identified by an index.
+
+!item [Ergebnis:]
+This function returns the corresponding sample index.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_load_sample]) ~
+vqspl_position_dma ~ vqspl_status_dma ~ vspl_pause_dma ~ vspl_play_dma ~
+vspl_stop_dma ~ vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_load_sample
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t vspl_load_sample( int16_t handle, int8_t *fname, uint32_t position );
+!item [Umsetzung:]
+!begin_verbatim
+int16_t vspl_load_sample(int16_t handle, int8_t *fname, uint32_t position)
+{
+   int16_t tmp;
+
+   intin[0..1] = position;
+
+   tmp = 2;
+   while (intin[tmp++] = *fname++)
+      ;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = --tmp;
+   contrl[5] = 3001;
+   contrl[6] = handle;
+
+   vdi();
+
+   return ( intout[0] );
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0]     !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1]     !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2]     !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3]     !! n     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4]     !! 1     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5]     !! 3001  # Escape/Sub-opcode
+contrl+12 !! contrl[6]     !! handle
+intin     !! intin[0..1]   !! position
+intin+4   !! intin[2..n-1] !! fname
+intout    !! intout[0]     !! (!nolink [Return])-Wert
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_make_d2d.ui
+++ b/gem/vdi/escape/sound/vspl_make_d2d.ui
@@ -1,0 +1,157 @@
+!iflang [english]
+
+
+!begin_node vspl_make_d2d
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Make D2D playback(!ldouble) - Continues D2D playback
+
+!item [Opcode:]
+5 (Escape 3020)
+
+!item [Syntax:]
+void vspl_make_d2d( int16_t handle );
+
+!item [Description:]
+The call vspl_make_d2d continues the D2D playback of the file previously started
+with vspl_play_d2d.
+
+The D2D status should be checked regularly with vqspl_status_d2d in order to
+call vspl_make_d2d whenever the system is ready.
+
+During this loop, buffoper(-1) has the bit 0 set to 1 throughout the playback.
+buffoper(-1) returns a value with bit 0 set to 0 at the end of the playback.
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_make_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_pause_d2d ~
+vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_make_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_make_d2d( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+void vspl_make_d2d (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3020;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 0     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3020  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_make_d2d
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Make D2D playback(!ldouble) - Continues D2D playback
+
+!item [VDI-Nummer:]
+5 (3020)
+
+!item [Deklaration:]
+void vspl_make_d2d( int16_t handle );
+
+!item [Beschreibung:]
+The call vspl_make_d2d continues the D2D playback of the file previously started
+with vspl_play_d2d.
+
+The D2D status should be checked regularly with vqspl_status_d2d in order to
+call vspl_make_d2d whenever the system is ready.
+
+During this loop, buffoper(-1) has the bit 0 set to 1 throughout the playback.
+buffoper(-1) returns a value with bit 0 set to 0 at the end of the playback.
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_make_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_pause_d2d ~
+vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_make_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_make_d2d( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+void vspl_make_d2d(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3020;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3020  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_pause_d2d.ui
+++ b/gem/vdi/escape/sound/vspl_pause_d2d.ui
@@ -1,0 +1,145 @@
+!iflang [english]
+
+
+!begin_node vspl_pause_d2d
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Pause D2D playback(!ldouble) - Suspends the D2D audio playback
+
+!item [Opcode:]
+5 (Escape 3014)
+
+!item [Syntax:]
+void vspl_pause_d2d( int16_t handle );
+
+!item [Description:]
+The call vspl_pause_d2d suspends the D2D playback of the file previously loaded
+with vspl_load_d2d.
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_pause_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_pause_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_pause_d2d( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+void vspl_pause_d2d (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3014;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 0     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3014  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_pause_d2d
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Pause D2D playback(!ldouble) - Suspends the D2D audio playback
+
+!item [VDI-Nummer:]
+5 (3014)
+
+!item [Deklaration:]
+void vspl_pause_d2d( int16_t handle );
+
+!item [Beschreibung:]
+The call vspl_pause_d2d suspends the D2D playback of the file previously loaded
+with vspl_load_d2d.
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_pause_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_play_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_pause_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_pause_d2d( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+void vspl_pause_d2d(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3014;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3014  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_pause_dma.ui
+++ b/gem/vdi/escape/sound/vspl_pause_dma.ui
@@ -1,0 +1,151 @@
+!iflang [english]
+
+
+!begin_node vspl_pause_dma
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Pause DMA playback(!ldouble) - Suspends the DMA playback of a sample
+
+!item [Opcode:]
+5 (Escape 3007)
+
+!item [Syntax:]
+void vspl_pause_dma( int16_t handle, int16_t id );
+
+!item [Description:]
+The call vspl_pause_dma suspends the DMA playback of the sample identified by
+(!I)id(!i).
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_pause_dma]) ~ vqspl_position_dma ~
+vqspl_status_dma ~ vspl_load_sample ~ vspl_play_dma ~ vspl_stop_dma ~
+vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_pause_dma
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_pause_dma( int16_t handle, int16_t id );
+!item [Binding:]
+!begin_verbatim
+void vspl_pause_dma (int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3007;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 1     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3007  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+intin     !! intin[0]  !! id
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_pause_dma
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Pause DMA playback(!ldouble) - Suspends the DMA playback of a sample
+
+!item [VDI-Nummer:]
+5 (3007)
+
+!item [Deklaration:]
+void vspl_pause_dma( int16_t handle, int16_t id );
+
+!item [Beschreibung:]
+The call vspl_pause_dma suspends the playback of the sample identified by
+(!I)id(!i).
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_pause_dma]) ~ vqspl_position_dma ~
+vqspl_status_dma ~ vspl_load_sample ~ vspl_play_dma ~ vspl_stop_dma ~
+vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_pause_dma
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_pause_dma( int16_t handle, int16_t id );
+!item [Umsetzung:]
+!begin_verbatim
+void vspl_pause_dma(int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3007;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 1     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3007  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+intin     !! intin[0]  !! id
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_play.ui
+++ b/gem/vdi/escape/sound/vspl_play.ui
@@ -1,0 +1,161 @@
+!iflang [english]
+
+
+!begin_node vspl_play
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Play sample(!ldouble) - Plays an audio file
+
+!item [Opcode:]
+5 (Escape 3000)
+
+!item [Syntax:]
+void vspl_play( int16_t handle, int8_t *fname, uint32_t position );
+
+!item [Description:]
+The call vspl_play starts the playback of the file (!I)fname(!i) from the
+position (!I)position(!i).
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_play])
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_play
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_play( int16_t handle, int8_t *fname, uint32_t position );
+!item [Binding:]
+!begin_verbatim
+void vspl_play (int16_t handle, int8_t *fname, uint32_t position)
+{
+   int16_t tmp;
+
+   intin[0..1] = position;
+
+   tmp = 2;
+   while (intin[tmp++] = *fname++)
+      ;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = --tmp;
+   contrl[5] = 3000;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0]     !! 5     # Function opcode
+contrl+2  !! contrl[1]     !! 0     # Entry in ptsin
+contrl+4  !! contrl[2]     !! 0     # Entry in ptsout
+contrl+6  !! contrl[3]     !! n     # Entry in intin
+contrl+8  !! contrl[4]     !! 0     # Entry in intout
+contrl+10 !! contrl[5]     !! 3000  # Escape/Sub-opcode
+contrl+12 !! contrl[6]     !! handle
+intin     !! intin[0..1]   !! position
+intin+4   !! intin[2..n-1] !! fname
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_play
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Play sample(!ldouble) - Plays an audio file
+
+!item [VDI-Nummer:]
+5 (3000)
+
+!item [Deklaration:]
+void vspl_play( int16_t handle, int8_t *fname, uint32_t position );
+
+!item [Beschreibung:]
+The call vspl_play starts the playback of the file (!I)fname(!i) from
+the position (!I)position(!i).
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_play])
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_play
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_play( int16_t handle, int8_t *fname, uint32_t position );
+!item [Umsetzung:]
+!begin_verbatim
+void vspl_play(int16_t handle, int8_t *fname, uint32_t position)
+{
+   int16_t tmp;
+
+   intin[0..1] = position;
+
+   tmp = 2;
+   while (intin[tmp++] = *fname++)
+      ;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = --tmp;
+   contrl[5] = 3000;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0]     !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1]     !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2]     !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3]     !! n     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4]     !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5]     !! 3000  # Escape/Sub-opcode
+contrl+12 !! contrl[6]     !! handle
+intin     !! intin[0..1]   !! position
+intin+4   !! intin[2..n-1] !! fname
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_play_d2d.ui
+++ b/gem/vdi/escape/sound/vspl_play_d2d.ui
@@ -1,0 +1,157 @@
+!iflang [english]
+
+
+!begin_node vspl_play_d2d
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Start D2D playback(!ldouble) - Plays an audio file through the D2D sound system
+
+!item [Opcode:]
+5 (Escape 3013)
+
+!item [Syntax:]
+void vspl_play_d2d( int16_t handle );
+
+!item [Description:]
+The call vspl_play_d2d starts the D2D playback of the file previously loaded
+with vspl_load_d2d.
+
+After calling this function, the D2D status should be checked regularly with
+vqspl_status_d2d in order to call vspl_make_d2d whenever the system is ready.
+
+During this loop, buffoper(-1) has the bit 0 set to 1 throughout the playback.
+buffoper(-1) returns a value with bit 0 set to 0 at the end of the playback.
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_play_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_pause_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_play_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_play_d2d( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+void vspl_play_d2d (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3013;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 0     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3013  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_play_d2d
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Start D2D playback(!ldouble) - Plays an audio file through the D2D sound system
+
+!item [VDI-Nummer:]
+5 (3013)
+
+!item [Deklaration:]
+void vspl_play_d2d( int16_t handle );
+
+!item [Beschreibung:]
+The call vspl_play_d2d starts the playback of the file previously loaded
+with vspl_load_d2d.
+
+After calling this function, the D2D status should be checked regularly with
+vqspl_status_d2d in order to call vspl_make_d2d whenever the system is ready.
+
+During this loop, buffoper(-1) has the bit 0 set to 1 throughout the playback.
+buffoper(-1) returns a value with bit 0 set to 0 at the end of the playback.
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_play_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_pause_d2d ~ vspl_stop_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_play_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_play_d2d( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+void vspl_play_d2d(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3013;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3013  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_play_dma.ui
+++ b/gem/vdi/escape/sound/vspl_play_dma.ui
@@ -1,0 +1,151 @@
+!iflang [english]
+
+
+!begin_node vspl_play_dma
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Start DMA playback(!ldouble) - Plays a sample through the DMA sound system
+
+!item [Opcode:]
+5 (Escape 3003)
+
+!item [Syntax:]
+void vspl_play_dma( int16_t handle, int16_t id );
+
+!item [Description:]
+The call vspl_play_dma starts the DMA playback of the sample identified by
+(!I)id(!i).
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_play_dma]) ~ vqspl_position_dma ~
+vqspl_status_dma ~ vspl_load_sample ~ vspl_pause_dma ~ vspl_stop_dma ~
+vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_play_dma
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_play_dma( int16_t handle, int16_t id );
+!item [Binding:]
+!begin_verbatim
+void vspl_play_dma (int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3003;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 1     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3003  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+intin     !! intin[0]  !! id
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_play_dma
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Start DMA playback(!ldouble) - Plays a sample through the DMA sound system
+
+!item [VDI-Nummer:]
+5 (3003)
+
+!item [Deklaration:]
+void vspl_play_dma( int16_t handle, int16_t id );
+
+!item [Beschreibung:]
+The call vspl_play_dma starts the playback of the sample identified by
+(!I)id(!i).
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_play_dma]) ~ vqspl_position_dma ~
+vqspl_status_dma ~ vspl_load_sample ~ vspl_pause_dma ~ vspl_stop_dma ~
+vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_play_dma
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_play_dma( int16_t handle, int16_t id );
+!item [Umsetzung:]
+!begin_verbatim
+void vspl_play_dma(int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3003;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 1     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3003  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+intin     !! intin[0]  !! id
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_stop_d2d.ui
+++ b/gem/vdi/escape/sound/vspl_stop_d2d.ui
@@ -1,0 +1,145 @@
+!iflang [english]
+
+
+!begin_node vspl_stop_d2d
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Stop D2D playback(!ldouble) - Stops the D2D audio playback
+
+!item [Opcode:]
+5 (Escape 3015)
+
+!item [Syntax:]
+void vspl_stop_d2d( int16_t handle );
+
+!item [Description:]
+The call vspl_stop_d2d stops the D2D playback of the file previously loaded
+with vspl_load_d2d.
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_stop_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_pause_d2d ~ vspl_play_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_stop_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_stop_d2d( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+void vspl_stop_d2d (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3015;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 0     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3015  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_stop_d2d
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Stop D2D playback(!ldouble) - Stops the D2D audio playback
+
+!item [VDI-Nummer:]
+5 (3015)
+
+!item [Deklaration:]
+void vspl_stop_d2d( int16_t handle );
+
+!item [Beschreibung:]
+The call vsp_stop_d2d stops the D2D playback of the file previously loaded
+with vspl_load_d2d.
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_stop_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_pause_d2d ~ vspl_play_d2d ~ vspl_unload_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_stop_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_stop_d2d( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+void vspl_stop_d2d(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3015;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3015  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_stop_dma.ui
+++ b/gem/vdi/escape/sound/vspl_stop_dma.ui
@@ -1,0 +1,151 @@
+!iflang [english]
+
+
+!begin_node vspl_stop_dma
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Stop DMA playback(!ldouble) - Stops the DMA playback of a sample
+
+!item [Opcode:]
+5 (Escape 3004)
+
+!item [Syntax:]
+void vspl_stop_dma( int16_t handle, int16_t id );
+
+!item [Description:]
+The call vspl_stop_dma stops the DMA playback of the sample identified by
+(!I)id(!i).
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_stop_dma]) ~ vqspl_position_dma ~
+vqspl_status_dma ~ vspl_load_sample ~ vspl_pause_dma ~ vspl_play_dma ~
+vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_stop_dma
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_stop_dma( int16_t handle, int16_t id );
+!item [Binding:]
+!begin_verbatim
+void vspl_stop_dma (int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3004;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 1     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3004  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+intin     !! intin[0]  !! id
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_stop_dma
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Stop DMA playback(!ldouble) - Stops the DMA playback of a sample
+
+!item [VDI-Nummer:]
+5 (3004)
+
+!item [Deklaration:]
+void vspl_stop_dma( int16_t handle, int16_t id );
+
+!item [Beschreibung:]
+The call vspl_stop_dma stops the playback of the sample identified by
+(!I)id(!i).
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_stop_dma]) ~ vqspl_position_dma ~
+vqspl_status_dma ~ vspl_load_sample ~ vspl_pause_dma ~ vspl_play_dma ~
+vspl_unload_sample
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_stop_dma
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_stop_dma( int16_t handle, int16_t id );
+!item [Umsetzung:]
+!begin_verbatim
+void vspl_stop_dma(int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3004;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 1     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3004  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+intin     !! intin[0]  !! id
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_unload_d2d.ui
+++ b/gem/vdi/escape/sound/vspl_unload_d2d.ui
@@ -1,0 +1,145 @@
+!iflang [english]
+
+
+!begin_node vspl_unload_d2d
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Unload D2D sample(!ldouble) - Unload an audio file
+
+!item [Opcode:]
+5 (Escape 3012)
+
+!item [Syntax:]
+void vspl_unload_d2d( int16_t handle );
+
+!item [Description:]
+The call vspl_unload_d2d releases the memory allocated with vspl_load_d2d for
+D2D playback.
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_unload_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_pause_d2d ~ vspl_play_d2d ~ vspl_stop_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_unload_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_unload_d2d( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+void vspl_unload_d2d (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3012;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 0     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3012  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_unload_d2d
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Unload D2D sample(!ldouble) - Unload an audio file
+
+!item [VDI-Nummer:]
+5 (3012)
+
+!item [Deklaration:]
+void vspl_unload_d2d( int16_t handle );
+
+!item [Beschreibung:]
+The call vspl_unload_d2d releases the memory allocated with vspl_load_d2d for
+MIDI playback.
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_unload_d2d]) ~ vqspl_position_d2d ~
+vqspl_status_d2d ~ vqspl_time_left_d2d ~ vspl_load_d2d ~ vspl_make_d2d ~
+vspl_pause_d2d ~ vspl_play_d2d ~ vspl_stop_d2d
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_unload_d2d
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_unload_d2d( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+void vspl_unload_d2d(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3012;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3012  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vspl_unload_sample.ui
+++ b/gem/vdi/escape/sound/vspl_unload_sample.ui
@@ -1,0 +1,149 @@
+!iflang [english]
+
+
+!begin_node vspl_unload_sample
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Unload sample(!ldouble) - Unloads a sample
+
+!item [Opcode:]
+5 (Escape 3002)
+
+!item [Syntax:]
+void vspl_unload_sample( int16_t handle, int16_t id );
+
+!item [Description:]
+The call vspl_unload_sample unloads the sample identified by (!I)id(!i).
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vspl_unload_sample]) ~ vqspl_position_dma ~
+vqspl_status_dma ~ vspl_load_sample ~ vspl_pause_dma ~ vspl_play_dma ~
+vspl_stop_dma
+
+(!ende_liste)
+
+
+!begin_node Bindings for vspl_unload_sample
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_unload_sample( int16_t handle, int16_t id );
+!item [Binding:]
+!begin_verbatim
+void vspl_unload_sample (int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3002;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 1     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3002  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+intin     !! intin[0]  !! id
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vspl_unload_sample
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Unload sample(!ldouble) - Unloads a sample
+
+!item [VDI-Nummer:]
+5 (3002)
+
+!item [Deklaration:]
+void vspl_unload_sample( int16_t handle, int16_t id );
+
+!item [Beschreibung:]
+The call vspl_unload_sample unloads the sample identified by (!I)id(!i).
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vspl_unload_sample]) ~
+vqspl_position_dma ~ vqspl_status_dma ~ vspl_load_sample ~ vspl_pause_dma ~
+vspl_play_dma ~ vspl_stop_dma
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vspl_unload_sample
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vspl_unload_sample( int16_t handle, int16_t id );
+!item [Umsetzung:]
+!begin_verbatim
+void vspl_unload_sample(int16_t handle, int16_t id)
+{
+   intin[0] = id;
+
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 1;
+   contrl[5] = 3002;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 1     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3002  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+intin     !! intin[0]  !! id
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vsspl_monitor_off.ui
+++ b/gem/vdi/escape/sound/vsspl_monitor_off.ui
@@ -1,0 +1,143 @@
+!iflang [english]
+
+
+!begin_node vsspl_monitor_off
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Monitor off(!ldouble) - Disables monitoring
+
+!item [Opcode:]
+5 (Escape 3031)
+
+!item [Syntax:]
+void vsspl_monitor_off( int16_t handle );
+
+!item [Description:]
+The call vsspl_monitor_off disables the monitoring of the sound system.
+
+(!B)Note:(!b) What the monitoring actually does is currently unknown.
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vsspl_monitor_off]) ~ vsspl_monitor_on
+
+(!ende_liste)
+
+
+!begin_node Bindings for vsspl_monitor_off
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vsspl_monitor_off( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+void vsspl_monitor_off (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3031;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 0     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3031  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vsspl_monitor_off
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Monitor off(!ldouble) - Disables monitoring of the sound system
+
+!item [VDI-Nummer:]
+5 (3031)
+
+!item [Deklaration:]
+void vsspl_monitor_off( int16_t handle );
+
+!item [Beschreibung:]
+The call vsspl_monitor_off disables the monitoring of the sound system.
+
+(!B)Note:(!b) What the monitoring actually does is currently unknown.
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vsspl_monitor_off]) ~ vsspl_monitor_on
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vsspl_monitor_off
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vsspl_monitor_off( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+void vsspl_monitor_off(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3031;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3031  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif

--- a/gem/vdi/escape/sound/vsspl_monitor_on.ui
+++ b/gem/vdi/escape/sound/vsspl_monitor_on.ui
@@ -1,0 +1,143 @@
+!iflang [english]
+
+
+!begin_node vsspl_monitor_on
+(!begin_liste) [Availability]
+
+!item [Name:]
+(!rdouble)Monitor on(!ldouble) - Enables monitoring
+
+!item [Opcode:]
+5 (Escape 3030)
+
+!item [Syntax:]
+void vsspl_monitor_on( int16_t handle );
+
+!item [Description:]
+The call vsspl_monitor_on enables the monitoring of the sound system.
+
+(!B)Note:(!b) What the monitoring actually does is currently unknown.
+
+!item [(!nolink [Return]) value:]
+This function does not return a result.
+
+!item [Availability:]
+SpeedoGDOS with sound driver.
+
+!item [Group:]
+Sound functions
+
+!item [See also:]
+(!link [Binding] [Bindings for vsspl_monitor_on]) ~ vsspl_monitor_off
+
+(!ende_liste)
+
+
+!begin_node Bindings for vsspl_monitor_on
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vsspl_monitor_on( int16_t handle );
+!item [Binding:]
+!begin_verbatim
+void vsspl_monitor_on (int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3030;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! Contents
+!hline
+contrl    !! contrl[0] !! 5     # Function opcode
+contrl+2  !! contrl[1] !! 0     # Entry in ptsin
+contrl+4  !! contrl[2] !! 0     # Entry in ptsout
+contrl+6  !! contrl[3] !! 0     # Entry in intin
+contrl+8  !! contrl[4] !! 0     # Entry in intout
+contrl+10 !! contrl[5] !! 3030  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!else
+
+
+!begin_node vsspl_monitor_on
+(!begin_liste) [Beschreibung]
+
+!item [Name:]
+(!rdouble)Monitor on(!ldouble) - Enables monitoring
+
+!item [VDI-Nummer:]
+5 (3030)
+
+!item [Deklaration:]
+void vsspl_monitor_on( int16_t handle );
+
+!item [Beschreibung:]
+The call vsspl_monitor_on enables the monitoring of the sound system.
+
+(!B)Note:(!b) What the monitoring actually does is currently unknown.
+
+!item [Ergebnis:]
+Die Funktion liefert kein Ergebnis.
+
+!item [Verf(!uumlaut)gbar:]
+SpeedoGDOS mit Sound-Treiber.
+
+!item [Gruppe:]
+Sound-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r vsspl_monitor_on]) ~ vsspl_monitor_off
+
+(!ende_liste)
+
+
+!begin_node Bindings f(!uumlaut)r vsspl_monitor_on
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void vsspl_monitor_on( int16_t handle );
+!item [Umsetzung:]
+!begin_verbatim
+void vsspl_monitor_on(int16_t handle)
+{
+   contrl[0] = 5;
+   contrl[1] = 0;
+   contrl[3] = 0;
+   contrl[5] = 3030;
+   contrl[6] = handle;
+
+   vdi();
+}
+!end_verbatim
+
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Addresse !! Feldelement !! Belegung
+!hline
+contrl    !! contrl[0] !! 5     # Opcode der Funktion
+contrl+2  !! contrl[1] !! 0     # Eintr(!aumlaut)ge in ptsin
+contrl+4  !! contrl[2] !! 0     # Eintr(!aumlaut)ge in ptsout
+contrl+6  !! contrl[3] !! 0     # Eintr(!aumlaut)ge in intin
+contrl+8  !! contrl[4] !! 0     # Eintr(!aumlaut)ge in intout
+contrl+10 !! contrl[5] !! 3030  # Escape/Sub-opcode
+contrl+12 !! contrl[6] !! handle
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+
+!endif


### PR DESCRIPTION
Some notes about sound functions:
- the unsigned long parameter 'position' is always set to 0 in examples. Bytes, position according to the number of bits and number of channels, seconds, milliseconds, ... I don't know
- what is monitoring expected to do? print info, write a log?

I added theses notes for both cases.

I'll add details later on return values from v_opnwk that help identify sound drivers (sample, MIDI and soundtrack; only sample and MIDI seem to be available)