### PR TITLE
Cosmetic changes to GEM/4 and ViewMAX (GEM versions)

### DIFF
--- a/gem/aes/aes_f.u
+++ b/gem/aes/aes_f.u
@@ -594,7 +594,7 @@ dez !! hex !! Funktionsname !! vorhanden
 1031 !! 0x407 !! xshl_setshell      !! (!nolink [FreeGEM]), 3.12.1999
 !hline
 28928 !! 0x7100 !! x_appl_flags     !! Geneva
-28929 !! 0x7101 !! x_appl_font      !! (!nolink [Geneva
+28929 !! 0x7101 !! x_appl_font      !! (!nolink [Geneva])
 28930 !! 0x7102 !! x_appl_sleep     !! (!nolink [Geneva])
 28931 !! 0x7103 !! x_appl_term      !! (!nolink [Geneva])
 28944 !! 0x7110 !! x_form_center    !! (!nolink [Geneva])

--- a/gem/aes/aes_f.u
+++ b/gem/aes/aes_f.u
@@ -7,12 +7,12 @@
 dec !! hex !! Function name !! Present in
 !hline
 0,0 !! 0x00 !! sys_set_getdisp             !! MagiC
-0,1 !! 0x00 !! sys_set_getfn               !! MagiC
-0,2 !! 0x00 !! sys_set_setfn               !! MagiC
-0,3 !! 0x00 !! sys_set_appl_getinfo        !! MagiC
-0,4 !! 0x00 !! sys_set_editob              !! MagiC
-0,5 !! 0x00 !! sys_recalc_cicon_colours    !! MagiC
-0,6 !! 0x00 !! sys_set_winframe_manager    !! MagiC 6
+0,1 !! 0x00 !! sys_set_getfn               !! (!nolink [MagiC])
+0,2 !! 0x00 !! sys_set_setfn               !! (!nolink [MagiC])
+0,3 !! 0x00 !! sys_set_appl_getinfo        !! (!nolink [MagiC])
+0,4 !! 0x00 !! sys_set_editob              !! (!nolink [MagiC])
+0,5 !! 0x00 !! sys_recalc_cicon_colours    !! (!nolink [MagiC])
+0,6 !! 0x00 !! sys_set_winframe_manager    !! (!nolink [MagiC]) 6
 !hline
 10 !! 0x0A  !! appl_init            !! (!nolink [TOS])
 11 !! 0x0B  !! appl_read            !! (!nolink [TOS])
@@ -21,8 +21,9 @@ dec !! hex !! Function name !! Present in
 14 !! 0x0E  !! appl_tplay           !! (!nolink [TOS])
 15 !! 0x0F  !! appl_trecord         !! (!nolink [TOS])
 16 !! 0x10  !! appl_bvset           !! ???
-17 !! 0x11  !! appl_yield           !! MagiC, (!nolink [N.AES])
+17 !! 0x11  !! appl_yield           !! (!nolink [MagiC]), N.AES
 18 !! 0x12  !! appl_search          !! (!nolink [TOS])
+18 !! 0x12  !! appl_xbvget          !! (!nolink [GEM])/4
 18 !! 0x12  !! appl_xbvset          !! (!nolink [GEM])/4
 19 !! 0x13  !! appl_exit            !! (!nolink [TOS])
 !hline
@@ -40,9 +41,9 @@ dec !! hex !! Function name !! Present in
 33 !! 0x21  !! menu_tnormal         !! (!nolink [TOS])
 34 !! 0x22  !! menu_text            !! (!nolink [TOS])
 35 !! 0x23  !! menu_register        !! (!nolink [TOS])
-36 !! 0x24  !! menu_unregister      !! MagiC
+36 !! 0x24  !! menu_unregister      !! (!nolink [MagiC])
 36 !! 0x24  !! menu_popup           !! (!nolink [TOS])
-37 !! 0x25  !! menu_click           !! MagiC
+37 !! 0x25  !! menu_click           !! (!nolink [MagiC])
 37 !! 0x25  !! menu_attach          !! (!nolink [TOS])
 38 !! 0x26  !! menu_istart          !! (!nolink [TOS])
 39 !! 0x27  !! menu_settings        !! (!nolink [TOS])
@@ -54,37 +55,38 @@ dec !! hex !! Function name !! Present in
 44 !! 0x2C  !! objc_offset          !! (!nolink [TOS])
 45 !! 0x2D  !! objc_order           !! (!nolink [TOS])
 46 !! 0x2E  !! objc_edit            !! (!nolink [TOS])
-46 !! 0x2E  !! objc_xedit           !! MagiC
+46 !! 0x2E  !! objc_xedit           !! (!nolink [MagiC])
 47 !! 0x2F  !! objc_change          !! (!nolink [TOS])
 48 !! 0x30  !! objc_sysvar          !! (!nolink [TOS])
 49 !! 0x31  !! objc_xfind           !! (!nolink [N.AES])
 !hline
 50 !! 0x32  !! form_do              !! (!nolink [TOS])
-50 !! 0x32  !! form_xdo             !! MagiC
+50 !! 0x32  !! form_xdo             !! (!nolink [MagiC])
 51 !! 0x33  !! form_dial            !! (!nolink [TOS])
-51 !! 0x33  !! form_xdial           !! MagiC
+51 !! 0x33  !! form_xdial           !! (!nolink [MagiC])
 52 !! 0x34  !! form_alert           !! (!nolink [TOS])
 53 !! 0x35  !! form_error           !! (!nolink [TOS])
 54 !! 0x36  !! form_center          !! (!nolink [TOS])
 55 !! 0x37  !! form_keybd           !! (!nolink [TOS])
 56 !! 0x38  !! form_button          !! (!nolink [TOS])
-57 !! 0x39  !! Modal entry form     !! (!nolink [GEM])/4
-58 !! 0x3A  !! Alert                !! (!nolink [GEM])/4
+57 !! 0x39  !!                      !! (!link [GEM/4][GEM/4]): Based on form_do but takes extra parameter
+58 !! 0x3A  !!                      !! (!nolink [GEM])/4: Based on form_alert but takes extra parameter
 !hline
-60 !! 0x3C  !! objc_wdraw           !! MagiC V5.10 (11.12.96) +
-60 !! 0x3C  !! proc_create          !! (!nolink [GEM]), Multiapp
-61 !! 0x3D  !! objc_wchange         !! MagiC V5.10 (11.12.96) +
-61 !! 0x3D  !! proc_run             !! (!nolink [GEM]), Multiapp
-62 !! 0x3E  !! graf_wwatchbox       !! MagiC V5.10 (11.12.96) +
-62 !! 0x3E  !! proc_delete          !! (!nolink [GEM]), Multiapp
-63 !! 0x3F  !! form_wbutton         !! MagiC V5.10 (11.12.96) +
-63 !! 0x3F  !! proc_info            !! (!nolink [GEM]), Multiapp
-64 !! 0x40  !! form_wkeybd          !! MagiC V5.10 (11.12.96) +
-64 !! 0x40  !! proc_malloc          !! (!nolink [GEM]), Multiapp
-65 !! 0x41  !! objc_wedit           !! MagiC V5.10 (11.12.96) +
-65 !! 0x41  !! proc_free            !! (!nolink [GEM]), Multiapp
-66 !! 0x42  !! proc_switch          !! (!nolink [GEM]), Multiapp
-67 !! 0x43  !! proc_setblock        !! (!nolink [GEM]), Multiapp
+60 !! 0x3C  !! objc_wdraw           !! (!nolink [MagiC]) V5.10 (11.12.96) +
+60 !! 0x3C  !! proc_create          !! GEM/XM
+61 !! 0x3D  !! objc_wchange         !! (!nolink [MagiC]) V5.10 (11.12.96) +
+61 !! 0x3D  !! proc_run             !! (!nolink [GEM])/XM
+62 !! 0x3E  !! graf_wwatchbox       !! (!nolink [MagiC]) V5.10 (11.12.96) +
+62 !! 0x3E  !! proc_delete          !! (!nolink [GEM])/XM
+63 !! 0x3F  !! form_wbutton         !! (!nolink [MagiC]) V5.10 (11.12.96) +
+63 !! 0x3F  !! proc_info            !! (!nolink [GEM])/XM
+64 !! 0x40  !! form_wkeybd          !! (!nolink [MagiC]) V5.10 (11.12.96) +
+64 !! 0x40  !! proc_malloc          !! (!nolink [GEM])/XM
+65 !! 0x41  !! objc_wedit           !! (!nolink [MagiC]) V5.10 (11.12.96) +
+65 !! 0x41  !! proc_mfree           !! (!nolink [GEM])/XM
+66 !! 0x42  !! proc_switch          !! (!nolink [GEM])/XM
+67 !! 0x43  !! proc_setblock        !! (!nolink [GEM])/XM
+68 !! 0x44  !! proc_shrink          !! (!nolink [GEM])/XM
 !hline
 69 !! 0x45  !! graf_multirubber     !! (!nolink [N.AES])
 70 !! 0x46  !! graf_rubberbox       !! (!nolink [TOS])
@@ -101,12 +103,12 @@ dec !! hex !! Function name !! Present in
 !hline
 80 !! 0x50  !! scrp_read            !! (!nolink [TOS])
 81 !! 0x51  !! scrp_write           !! (!nolink [TOS])
-82 !! 0x52  !! scrp_clear           !! MagiC
+82 !! 0x52  !! scrp_clear           !! (!nolink [MagiC])
 !hline
 90 !! 0x5A  !! fsel_input           !! (!nolink [TOS])
 91 !! 0x5B  !! fsel_exinput         !! (!nolink [TOS])
 91 !! 0x5B  !! fsel_boxinput        !! As of  BoxKite 1.71
-91 !! 0x5B  !! File selector        !! (!nolink [GEM])/4, (!nolink [GEM])/5
+91 !! 0x5B  !!                      !! (!nolink [GEM])/4, (!nolink [GEM])/5: Based on fsel_input but takes extra parameter
 !hline
 99 !! 0x63  !! wind_draw            !! (!nolink [N.AES])
 100 !! 0x64 !! wind_create          !! (!nolink [TOS])
@@ -126,8 +128,8 @@ dec !! hex !! Function name !! Present in
 113 !! 0x71 !! rsrc_saddr           !! (!nolink [TOS])
 114 !! 0x72 !! rsrc_obfix           !! (!nolink [TOS])
 115 !! 0x73 !! rsrc_rcfix           !! (!nolink [MTOS])
-115 !! 0x73 !! Load resources (supports EMS)  !! (!nolink [GEM])/4, (!nolink [GEM])/5
-116 !! 0x74 !! manipulate resources in EMS    !! (!nolink [GEM])/4, (!nolink [GEM])/5
+115 !! 0x73 !!                      !! (!nolink [GEM])/4, (!nolink [GEM])/5: Based on rsrc_load, supports EMS
+116 !! 0x74 !!                      !! (!nolink [GEM])/4, (!nolink [GEM])/5: Manipulates resources in EMS
 119 !! 0x77 !! wind_apfind          !! Multi(!nolink [GEM])2
 !hline
 120 !! 0x78 !! shel_read            !! (!nolink [TOS])
@@ -146,13 +148,13 @@ dec !! hex !! Function name !! Present in
 131 !! 0x83 !! appl_getcicon        !! MyAES
 131 !! 0x83 !! xgrf_2box            !! (!nolink [GEM])/3
 132 !! 0x84 !! xgrf_color           !! ViewMAX
-133 !! 0x85 !! xgrf_dtimage         !! ViewMAX Panther
-135 !! 0x87 !! form_popup           !! MagiC
-135 !! 0x87 !! xfrm_popup           !! MagiC 5.03
-136 !! 0x88 !! form_xerr            !! MagiC
+133 !! 0x85 !! xgrf_dtimage         !! (!nolink [ViewMAX]) Panther
+135 !! 0x87 !! form_popup           !! (!nolink [MagiC])
+135 !! 0x87 !! xfrm_popup           !! (!nolink [MagiC]) 5.03
+136 !! 0x88 !! form_xerr            !! (!nolink [MagiC])
 137 !! 0x89 !! appl_options         !! XaAES
 !hline
-140 !! 0x8c !! objc_data            !! XaAES
+140 !! 0x8c !! objc_data            !! (!nolink [XaAES])
 !hline
 160 !! 0xA0 !! wdlg_create          !! WDialog
 161 !! 0xA1 !! wdlg_open            !! WDialog
@@ -210,12 +212,12 @@ dec !! hex !! Function name !! Present in
 186 !! 0xBA !! fnts_evnt            !! WDialog
 187 !! 0xBB !! fnts_do              !! WDialog
 !hline
-190 !! 0xBE !! fslx_open            !! MagiC
-191 !! 0xBF !! fslx_close           !! MagiC
-192 !! 0xC0 !! fslx_getnxtfile      !! MagiC
-193 !! 0xC1 !! fslx_evnt            !! MagiC
-194 !! 0xC2 !! fslx_do              !! MagiC
-195 !! 0xC3 !! fslx_set_flags       !! MagiC
+190 !! 0xBE !! fslx_open            !! (!nolink [MagiC])
+191 !! 0xBF !! fslx_close           !! (!nolink [MagiC])
+192 !! 0xC0 !! fslx_getnxtfile      !! (!nolink [MagiC])
+193 !! 0xC1 !! fslx_evnt            !! (!nolink [MagiC])
+194 !! 0xC2 !! fslx_do              !! (!nolink [MagiC])
+195 !! 0xC3 !! fslx_set_flags       !! (!nolink [MagiC])
 !hline
 200 !! 0xC8 !! pdlg_create          !! WDialog
 201 !! 0xC9 !! pdlg_delete          !! WDialog
@@ -236,30 +238,30 @@ dec !! hex !! Function name !! Present in
 206 !! 0xCE !! pdlg_evnt            !! WDialog
 207 !! 0xCF !! pdlg_do              !! WDialog
 !hline
-210 !! 0xD2 !! edit_create          !! MagiC 5.20
-211 !! 0xD3 !! edit_open            !! MagiC 5.20
-212 !! 0xD4 !! edit_close           !! MagiC 5.20
-213 !! 0xD5 !! edit_delete          !! MagiC 5.20
-214 !! 0xD6 !! edit_cursor          !! MagiC 5.20
-215 !! 0xD7 !! edit_evnt            !! MagiC 5.20
-216,0 !! 0xD8 !! edit_get_buf       !! MagiC 5.20
-216,1 !! 0xD8 !! edit_get_format    !! MagiC 5.20
-216,2 !! 0xD8 !! edit_get_colour    !! MagiC 5.20
-216,3 !! 0xD8 !! edit_get_font      !! MagiC 5.20
-216,4 !! 0xD8 !! edit_get_cursor    !! MagiC 5.20
-216,5 !! 0xD8 !! edit_get_pos       !! MagiC 5.20
-216,7 !! 0xD8 !! edit_get_dirty     !! MagiC 5.20
-216,8 !! 0xD8 !! edit_get_sel       !! MagiC 5.20
-216,9 !! 0xD8 !! edit_get_scrollinfo !! MagiC 5.20
-217,0 !! 0xD9 !! edit_set_buf       !! MagiC 5.20
-217,1 !! 0xD9 !! edit_set_format    !! MagiC 5.20
-217,2 !! 0xD9 !! edit_set_colour    !! MagiC 5.20
-217,3 !! 0xD9 !! edit_set_font      !! MagiC 5.20
-217,4 !! 0xD9 !! edit_set_cursor    !! MagiC 5.20
-217,5 !! 0xD9 !! edit_set_pos       !! MagiC 5.20
-217,6 !! 0xD9 !! edit_resized       !! MagiC 5.20
-217,7 !! 0xD9 !! edit_set_dirty     !! MagiC 5.20
-217,9 !! 0xD9 !! edit_scroll        !! MagiC 5.20
+210 !! 0xD2 !! edit_create          !! (!nolink [MagiC]) 5.20
+211 !! 0xD3 !! edit_open            !! (!nolink [MagiC]) 5.20
+212 !! 0xD4 !! edit_close           !! (!nolink [MagiC]) 5.20
+213 !! 0xD5 !! edit_delete          !! (!nolink [MagiC]) 5.20
+214 !! 0xD6 !! edit_cursor          !! (!nolink [MagiC]) 5.20
+215 !! 0xD7 !! edit_evnt            !! (!nolink [MagiC]) 5.20
+216,0 !! 0xD8 !! edit_get_buf       !! (!nolink [MagiC]) 5.20
+216,1 !! 0xD8 !! edit_get_format    !! (!nolink [MagiC]) 5.20
+216,2 !! 0xD8 !! edit_get_colour    !! (!nolink [MagiC]) 5.20
+216,3 !! 0xD8 !! edit_get_font      !! (!nolink [MagiC]) 5.20
+216,4 !! 0xD8 !! edit_get_cursor    !! (!nolink [MagiC]) 5.20
+216,5 !! 0xD8 !! edit_get_pos       !! (!nolink [MagiC]) 5.20
+216,7 !! 0xD8 !! edit_get_dirty     !! (!nolink [MagiC]) 5.20
+216,8 !! 0xD8 !! edit_get_sel       !! (!nolink [MagiC]) 5.20
+216,9 !! 0xD8 !! edit_get_scrollinfo !! (!nolink [MagiC]) 5.20
+217,0 !! 0xD9 !! edit_set_buf       !! (!nolink [MagiC]) 5.20
+217,1 !! 0xD9 !! edit_set_format    !! (!nolink [MagiC]) 5.20
+217,2 !! 0xD9 !! edit_set_colour    !! (!nolink [MagiC]) 5.20
+217,3 !! 0xD9 !! edit_set_font      !! (!nolink [MagiC]) 5.20
+217,4 !! 0xD9 !! edit_set_cursor    !! (!nolink [MagiC]) 5.20
+217,5 !! 0xD9 !! edit_set_pos       !! (!nolink [MagiC]) 5.20
+217,6 !! 0xD9 !! edit_resized       !! (!nolink [MagiC]) 5.20
+217,7 !! 0xD9 !! edit_set_dirty     !! (!nolink [MagiC]) 5.20
+217,9 !! 0xD9 !! edit_scroll        !! (!nolink [MagiC]) 5.20
 !hline
 250 !! 0xFA !! button_click         !! Up to (!nolink [XaAES]) v0.963
 251 !! 0xFB !! new_client           !! Up to (!nolink [XaAES]) v0.963
@@ -269,43 +271,43 @@ dec !! hex !! Function name !! Present in
 260 !! 0x104 !! appl_pipe           !! Up to (!nolink [XaAES]) v0.963
 !hline
 1010 !! 0x3F2 !! prop_get           !! FreeGEM, 25.7.1999
-1011 !! 0x3F3 !! prop_put           !! FreeGEM, 25.7.1999
-1012 !! 0x3F4 !! prop_del           !! FreeGEM, 25.7.1999
-1013 !! 0x3F5 !! prop_gui_get       !! FreeGEM3, 22.3.2000
-1014 !! 0x3F6 !! prop_gui_set       !! FreeGEM3, 22.3.2000
-1020 !! 0x3FC !! x_appl_getinfo     !! FreeGEM, 8.8.1999
-1030 !! 0x406 !! xshl_getshell      !! FreeGEM, 3.12.1999
-1031 !! 0x407 !! xshl_setshell      !! FreeGEM, 3.12.1999
+1011 !! 0x3F3 !! prop_put           !! (!nolink [FreeGEM]), 25.7.1999
+1012 !! 0x3F4 !! prop_del           !! (!nolink [FreeGEM]), 25.7.1999
+1013 !! 0x3F5 !! prop_gui_get       !! (!nolink [FreeGEM]), 22.3.2000
+1014 !! 0x3F6 !! prop_gui_set       !! (!nolink [FreeGEM]), 22.3.2000
+1020 !! 0x3FC !! xapp_getinfo       !! (!nolink [FreeGEM]), 8.8.1999
+1030 !! 0x406 !! xshl_getshell      !! (!nolink [FreeGEM]), 3.12.1999
+1031 !! 0x407 !! xshl_setshell      !! (!nolink [FreeGEM]), 3.12.1999
 !hline
 28928 !! 0x7100 !! x_appl_flags     !! Geneva
-28929 !! 0x7101 !! x_appl_font      !! Geneva
-28930 !! 0x7102 !! x_appl_sleep     !! Geneva
-28931 !! 0x7103 !! x_appl_term      !! Geneva
-28944 !! 0x7110 !! x_form_center    !! Geneva
-28945 !! 0x7111 !! x_form_error     !! Geneva
-28946 !! 0x7112 !! x_form_filename  !! Geneva
-28947 !! 0x7113 !! x_form_mouse     !! Geneva
-28960 !! 0x7120 !! x_fsel_input     !! Geneva
-28976 !! 0x7130 !! x_graf_blit      !! Geneva
-28977 !! 0x7131 !! x_graf_rubberbox !! Geneva
-28978 !! 0x7132 !! x_graf_rast2rez  !! Geneva 004
-28992 !! 0x7140 !! x_objc_edit      !! Geneva
-29008 !! 0x7150 !! x_wdial_draw     !! Geneva
-29009 !! 0x7151 !! x_wdial_change   !! Geneva
-29010 !! 0x7152 !! x_wind_tree      !! Geneva
-29011 !! 0x7153 !! x_wind_create    !! Geneva
-29012 !! 0x7154 !! x_wind_calc      !! Geneva
-29024 !! 0x7160 !! x_scrp_get       !! Geneva 004
-29056 !! 0x7180 !! x_settings       !! Geneva
-29057 !! 0x7181 !! x_shel_get       !! Geneva
-29058 !! 0x7182 !! x_shel_put       !! Geneva
-29059 !! 0x7183 !! x_sprintf        !! Geneva
-29060 !! 0x7184 !! x_sscanf         !! Geneva
-29061 !! 0x7185 !! x_help           !! Geneva
-29062 !! 0x7186 !! x_malloc         !! Geneva 004
-29063 !! 0x7187 !! x_mfree          !! Geneva 004
-29064 !! 0x7188 !! x_mshrink        !! Geneva 004
-29065 !! 0x7189 !! x_realloc        !! Geneva 004
+28929 !! 0x7101 !! x_appl_font      !! (!nolink [Geneva])
+28930 !! 0x7102 !! x_appl_sleep     !! (!nolink [Geneva])
+28931 !! 0x7103 !! x_appl_term      !! (!nolink [Geneva])
+28944 !! 0x7110 !! x_form_center    !! (!nolink [Geneva])
+28945 !! 0x7111 !! x_form_error     !! (!nolink [Geneva])
+28946 !! 0x7112 !! x_form_filename  !! (!nolink [Geneva])
+28947 !! 0x7113 !! x_form_mouse     !! (!nolink [Geneva])
+28960 !! 0x7120 !! x_fsel_input     !! (!nolink [Geneva])
+28976 !! 0x7130 !! x_graf_blit      !! (!nolink [Geneva])
+28977 !! 0x7131 !! x_graf_rubberbox !! (!nolink [Geneva])
+28978 !! 0x7132 !! x_graf_rast2rez  !! (!nolink [Geneva]) 004
+28992 !! 0x7140 !! x_objc_edit      !! (!nolink [Geneva])
+29008 !! 0x7150 !! x_wdial_draw     !! (!nolink [Geneva])
+29009 !! 0x7151 !! x_wdial_change   !! (!nolink [Geneva])
+29010 !! 0x7152 !! x_wind_tree      !! (!nolink [Geneva])
+29011 !! 0x7153 !! x_wind_create    !! (!nolink [Geneva])
+29012 !! 0x7154 !! x_wind_calc      !! (!nolink [Geneva])
+29024 !! 0x7160 !! x_scrp_get       !! (!nolink [Geneva]) 004
+29056 !! 0x7180 !! x_settings       !! (!nolink [Geneva])
+29057 !! 0x7181 !! x_shel_get       !! (!nolink [Geneva])
+29058 !! 0x7182 !! x_shel_put       !! (!nolink [Geneva])
+29059 !! 0x7183 !! x_sprintf        !! (!nolink [Geneva])
+29060 !! 0x7184 !! x_sscanf         !! (!nolink [Geneva])
+29061 !! 0x7185 !! x_help           !! (!nolink [Geneva])
+29062 !! 0x7186 !! x_malloc         !! (!nolink [Geneva]) 004
+29063 !! 0x7187 !! x_mfree          !! (!nolink [Geneva]) 004
+29064 !! 0x7188 !! x_mshrink        !! (!nolink [Geneva]) 004
+29065 !! 0x7189 !! x_realloc        !! (!nolink [Geneva]) 004
 !hline
 !end_table
 !end_node
@@ -319,12 +321,12 @@ dec !! hex !! Function name !! Present in
 dez !! hex !! Funktionsname !! vorhanden
 !hline
 0,0 !! 0x00 !! sys_set_getdisp             !! MagiC
-0,1 !! 0x00 !! sys_set_getfn               !! MagiC
-0,2 !! 0x00 !! sys_set_setfn               !! MagiC
-0,3 !! 0x00 !! sys_set_appl_getinfo        !! MagiC
-0,4 !! 0x00 !! sys_set_editob              !! MagiC
-0,5 !! 0x00 !! sys_recalc_cicon_colours    !! MagiC
-0,6 !! 0x00 !! sys_set_winframe_manager    !! MagiC 6
+0,1 !! 0x00 !! sys_set_getfn               !! (!nolink [MagiC])
+0,2 !! 0x00 !! sys_set_setfn               !! (!nolink [MagiC])
+0,3 !! 0x00 !! sys_set_appl_getinfo        !! (!nolink [MagiC])
+0,4 !! 0x00 !! sys_set_editob              !! (!nolink [MagiC])
+0,5 !! 0x00 !! sys_recalc_cicon_colours    !! (!nolink [MagiC])
+0,6 !! 0x00 !! sys_set_winframe_manager    !! (!nolink [MagiC]) 6
 !hline
 10 !! 0x0A  !! appl_init            !! (!nolink [TOS])
 11 !! 0x0B  !! appl_read            !! (!nolink [TOS])
@@ -333,8 +335,9 @@ dez !! hex !! Funktionsname !! vorhanden
 14 !! 0x0E  !! appl_tplay           !! (!nolink [TOS])
 15 !! 0x0F  !! appl_trecord         !! (!nolink [TOS])
 16 !! 0x10  !! appl_bvset           !! ???
-17 !! 0x11  !! appl_yield           !! MagiC, (!nolink [N.AES])
+17 !! 0x11  !! appl_yield           !! (!nolink [MagiC]), N.AES
 18 !! 0x12  !! appl_search          !! (!nolink [TOS])
+18 !! 0x12  !! appl_xbvget          !! (!nolink [GEM])/4
 18 !! 0x12  !! appl_xbvset          !! (!nolink [GEM])/4
 19 !! 0x13  !! appl_exit            !! (!nolink [TOS])
 !hline
@@ -352,9 +355,9 @@ dez !! hex !! Funktionsname !! vorhanden
 33 !! 0x21  !! menu_tnormal         !! (!nolink [TOS])
 34 !! 0x22  !! menu_text            !! (!nolink [TOS])
 35 !! 0x23  !! menu_register        !! (!nolink [TOS])
-36 !! 0x24  !! menu_unregister      !! MagiC
+36 !! 0x24  !! menu_unregister      !! (!nolink [MagiC])
 36 !! 0x24  !! menu_popup           !! (!nolink [TOS])
-37 !! 0x25  !! menu_click           !! MagiC
+37 !! 0x25  !! menu_click           !! (!nolink [MagiC])
 37 !! 0x25  !! menu_attach          !! (!nolink [TOS])
 38 !! 0x26  !! menu_istart          !! (!nolink [TOS])
 39 !! 0x27  !! menu_settings        !! (!nolink [TOS])
@@ -366,37 +369,38 @@ dez !! hex !! Funktionsname !! vorhanden
 44 !! 0x2C  !! objc_offset          !! (!nolink [TOS])
 45 !! 0x2D  !! objc_order           !! (!nolink [TOS])
 46 !! 0x2E  !! objc_edit            !! (!nolink [TOS])
-46 !! 0x2E  !! objc_xedit           !! MagiC
+46 !! 0x2E  !! objc_xedit           !! (!nolink [MagiC])
 47 !! 0x2F  !! objc_change          !! (!nolink [TOS])
 48 !! 0x30  !! objc_sysvar          !! (!nolink [TOS])
 49 !! 0x31  !! objc_xfind           !! (!nolink [N.AES])
 !hline
 50 !! 0x32  !! form_do              !! (!nolink [TOS])
-50 !! 0x32  !! form_xdo             !! MagiC
+50 !! 0x32  !! form_xdo             !! (!nolink [MagiC])
 51 !! 0x33  !! form_dial            !! (!nolink [TOS])
-51 !! 0x33  !! form_xdial           !! MagiC
+51 !! 0x33  !! form_xdial           !! (!nolink [MagiC])
 52 !! 0x34  !! form_alert           !! (!nolink [TOS])
 53 !! 0x35  !! form_error           !! (!nolink [TOS])
 54 !! 0x36  !! form_center          !! (!nolink [TOS])
 55 !! 0x37  !! form_keybd           !! (!nolink [TOS])
 56 !! 0x38  !! form_button          !! (!nolink [TOS])
-57 !! 0x39  !! Modal entry form     !! (!nolink [GEM])/4
-58 !! 0x3A  !! Alert                !! (!nolink [GEM])/4
+57 !! 0x39  !!                      !! (!link [GEM/4][GEM/4]): Based on form_do but takes extra parameter
+58 !! 0x3A  !!                      !! (!nolink [GEM])/4: Based on form_alert but takes extra parameter
 !hline
-60 !! 0x3C  !! objc_wdraw           !! MagiC, ab 11.12.96, V5.10
-60 !! 0x3C  !! proc_create          !! (!nolink [GEM]), Multiapp
-61 !! 0x3D  !! objc_wchange         !! MagiC, ab 11.12.96, V5.10
-61 !! 0x3D  !! proc_run             !! (!nolink [GEM]), Multiapp
-62 !! 0x3E  !! graf_wwatchbox       !! MagiC, ab 11.12.96, V5.10
-62 !! 0x3E  !! proc_delete          !! (!nolink [GEM]), Multiapp
-63 !! 0x3F  !! form_wbutton         !! MagiC, ab 11.12.96, V5.10
-63 !! 0x3F  !! proc_info            !! (!nolink [GEM]), Multiapp
-64 !! 0x40  !! form_wkeybd          !! MagiC, ab 11.12.96, V5.10
-64 !! 0x40  !! proc_malloc          !! (!nolink [GEM]), Multiapp
-65 !! 0x41  !! objc_wedit           !! MagiC, ab 11.12.96, V5.10
-65 !! 0x41  !! proc_free            !! (!nolink [GEM]), Multiapp
-66 !! 0x42  !! proc_switch          !! (!nolink [GEM]), Multiapp
-67 !! 0x43  !! proc_setblock        !! (!nolink [GEM]), Multiapp
+60 !! 0x3C  !! objc_wdraw           !! (!nolink [MagiC]), ab 11.12.96, V5.10
+60 !! 0x3C  !! proc_create          !! GEM/XM
+61 !! 0x3D  !! objc_wchange         !! (!nolink [MagiC]), ab 11.12.96, V5.10
+61 !! 0x3D  !! proc_run             !! (!nolink [GEM])/XM
+62 !! 0x3E  !! graf_wwatchbox       !! (!nolink [MagiC]), ab 11.12.96, V5.10
+62 !! 0x3E  !! proc_delete          !! (!nolink [GEM])/XM
+63 !! 0x3F  !! form_wbutton         !! (!nolink [MagiC]), ab 11.12.96, V5.10
+63 !! 0x3F  !! proc_info            !! (!nolink [GEM])/XM
+64 !! 0x40  !! form_wkeybd          !! (!nolink [MagiC]), ab 11.12.96, V5.10
+64 !! 0x40  !! proc_malloc          !! (!nolink [GEM])/XM
+65 !! 0x41  !! objc_wedit           !! (!nolink [MagiC]), ab 11.12.96, V5.10
+65 !! 0x41  !! proc_mfree           !! (!nolink [GEM])/XM
+66 !! 0x42  !! proc_switch          !! (!nolink [GEM])/XM
+67 !! 0x43  !! proc_setblock        !! (!nolink [GEM])/XM
+68 !! 0x44  !! proc_shrink          !! (!nolink [GEM])/XM
 !hline
 69 !! 0x45  !! graf_multirubber     !! (!nolink [N.AES])
 70 !! 0x46  !! graf_rubberbox       !! (!nolink [TOS])
@@ -413,12 +417,12 @@ dez !! hex !! Funktionsname !! vorhanden
 !hline
 80 !! 0x50  !! scrp_read            !! (!nolink [TOS])
 81 !! 0x51  !! scrp_write           !! (!nolink [TOS])
-82 !! 0x52  !! scrp_clear           !! MagiC
+82 !! 0x52  !! scrp_clear           !! (!nolink [MagiC])
 !hline
 90 !! 0x5A  !! fsel_input           !! (!nolink [TOS])
 91 !! 0x5B  !! fsel_exinput         !! (!nolink [TOS])
 91 !! 0x5B  !! fsel_boxinput        !! since BoxKite 1.71
-91 !! 0x5B  !! File selector        !! (!nolink [GEM])/4, (!nolink [GEM])/5
+91 !! 0x5B  !!                      !! (!nolink [GEM])/4, (!nolink [GEM])/5: Based on fsel_input but takes extra parameter
 !hline
 99 !! 0x63  !! wind_draw            !! (!nolink [N.AES])
 100 !! 0x64 !! wind_create          !! (!nolink [TOS])
@@ -438,8 +442,8 @@ dez !! hex !! Funktionsname !! vorhanden
 113 !! 0x71 !! rsrc_saddr           !! (!nolink [TOS])
 114 !! 0x72 !! rsrc_obfix           !! (!nolink [TOS])
 115 !! 0x73 !! rsrc_rcfix           !! (!nolink [MTOS])
-115 !! 0x73 !! Load resources (supports EMS)  !! (!nolink [GEM])/4, (!nolink [GEM])/5
-116 !! 0x74 !! manipulate resources in EMS    !! (!nolink [GEM])/4, (!nolink [GEM])/5
+115 !! 0x73 !!                      !! (!nolink [GEM])/4, (!nolink [GEM])/5: Based on rsrc_load, supports EMS
+116 !! 0x74 !!                      !! (!nolink [GEM])/4, (!nolink [GEM])/5: Manipulates resources in EMS
 119 !! 0x77 !! wind_apfind          !! Multi(!nolink [GEM])2
 !hline
 120 !! 0x78 !! shel_read            !! (!nolink [TOS])
@@ -458,13 +462,13 @@ dez !! hex !! Funktionsname !! vorhanden
 131 !! 0x83 !! appl_getcicon        !! MyAES
 131 !! 0x83 !! xgrf_2box            !! (!nolink [GEM])/3
 132 !! 0x84 !! xgrf_color           !! ViewMAX
-133 !! 0x85 !! xgrf_dtimage         !! ViewMAX Panther
-135 !! 0x87 !! form_popup           !! MagiC
-135 !! 0x87 !! xfrm_popup           !! MagiC 5.03
-136 !! 0x88 !! form_xerr            !! MagiC
+133 !! 0x85 !! xgrf_dtimage         !! (!nolink [ViewMAX]) Panther
+135 !! 0x87 !! form_popup           !! (!nolink [MagiC])
+135 !! 0x87 !! xfrm_popup           !! (!nolink [MagiC]) 5.03
+136 !! 0x88 !! form_xerr            !! (!nolink [MagiC])
 137 !! 0x89 !! appl_options         !! XaAES
 !hline
-140 !! 0x8c !! objc_data            !! XaAES
+140 !! 0x8c !! objc_data            !! (!nolink [XaAES])
 !hline
 160 !! 0xA0 !! wdlg_create          !! WDialog
 161 !! 0xA1 !! wdlg_open            !! WDialog
@@ -522,12 +526,12 @@ dez !! hex !! Funktionsname !! vorhanden
 186 !! 0xBA !! fnts_evnt            !! WDialog
 187 !! 0xBB !! fnts_do              !! WDialog
 !hline
-190 !! 0xBE !! fslx_open            !! MagiC
-191 !! 0xBF !! fslx_close           !! MagiC
-192 !! 0xC0 !! fslx_getnxtfile      !! MagiC
-193 !! 0xC1 !! fslx_evnt            !! MagiC
-194 !! 0xC2 !! fslx_do              !! MagiC
-195 !! 0xC3 !! fslx_set_flags       !! MagiC
+190 !! 0xBE !! fslx_open            !! (!nolink [MagiC])
+191 !! 0xBF !! fslx_close           !! (!nolink [MagiC])
+192 !! 0xC0 !! fslx_getnxtfile      !! (!nolink [MagiC])
+193 !! 0xC1 !! fslx_evnt            !! (!nolink [MagiC])
+194 !! 0xC2 !! fslx_do              !! (!nolink [MagiC])
+195 !! 0xC3 !! fslx_set_flags       !! (!nolink [MagiC])
 !hline
 200 !! 0xC8 !! pdlg_create          !! WDialog
 201 !! 0xC9 !! pdlg_delete          !! WDialog
@@ -548,30 +552,30 @@ dez !! hex !! Funktionsname !! vorhanden
 206 !! 0xCE !! pdlg_evnt            !! WDialog
 207 !! 0xCF !! pdlg_do              !! WDialog
 !hline
-210 !! 0xD2 !! edit_create          !! MagiC 5.20
-211 !! 0xD3 !! edit_open            !! MagiC 5.20
-212 !! 0xD4 !! edit_close           !! MagiC 5.20
-213 !! 0xD5 !! edit_delete          !! MagiC 5.20
-214 !! 0xD6 !! edit_cursor          !! MagiC 5.20
-215 !! 0xD7 !! edit_evnt            !! MagiC 5.20
-216,0 !! 0xD8 !! edit_get_buf       !! MagiC 5.20
-216,1 !! 0xD8 !! edit_get_format    !! MagiC 5.20
-216,2 !! 0xD8 !! edit_get_colour    !! MagiC 5.20
-216,3 !! 0xD8 !! edit_get_font      !! MagiC 5.20
-216,4 !! 0xD8 !! edit_get_cursor    !! MagiC 5.20
-216,5 !! 0xD8 !! edit_get_pos       !! MagiC 5.20
-216,7 !! 0xD8 !! edit_get_dirty     !! MagiC 5.20
-216,8 !! 0xD8 !! edit_get_sel       !! MagiC 5.20
-216,9 !! 0xD8 !! edit_get_scrollinfo !! MagiC 5.20
-217,0 !! 0xD9 !! edit_set_buf       !! MagiC 5.20
-217,1 !! 0xD9 !! edit_set_format    !! MagiC 5.20
-217,2 !! 0xD9 !! edit_set_colour    !! MagiC 5.20
-217,3 !! 0xD9 !! edit_set_font      !! MagiC 5.20
-217,4 !! 0xD9 !! edit_set_cursor    !! MagiC 5.20
-217,5 !! 0xD9 !! edit_set_pos       !! MagiC 5.20
-217,6 !! 0xD9 !! edit_resized       !! MagiC 5.20
-217,7 !! 0xD9 !! edit_set_dirty     !! MagiC 5.20
-217,9 !! 0xD9 !! edit_scroll        !! MagiC 5.20
+210 !! 0xD2 !! edit_create          !! (!nolink [MagiC]) 5.20
+211 !! 0xD3 !! edit_open            !! (!nolink [MagiC]) 5.20
+212 !! 0xD4 !! edit_close           !! (!nolink [MagiC]) 5.20
+213 !! 0xD5 !! edit_delete          !! (!nolink [MagiC]) 5.20
+214 !! 0xD6 !! edit_cursor          !! (!nolink [MagiC]) 5.20
+215 !! 0xD7 !! edit_evnt            !! (!nolink [MagiC]) 5.20
+216,0 !! 0xD8 !! edit_get_buf       !! (!nolink [MagiC]) 5.20
+216,1 !! 0xD8 !! edit_get_format    !! (!nolink [MagiC]) 5.20
+216,2 !! 0xD8 !! edit_get_colour    !! (!nolink [MagiC]) 5.20
+216,3 !! 0xD8 !! edit_get_font      !! (!nolink [MagiC]) 5.20
+216,4 !! 0xD8 !! edit_get_cursor    !! (!nolink [MagiC]) 5.20
+216,5 !! 0xD8 !! edit_get_pos       !! (!nolink [MagiC]) 5.20
+216,7 !! 0xD8 !! edit_get_dirty     !! (!nolink [MagiC]) 5.20
+216,8 !! 0xD8 !! edit_get_sel       !! (!nolink [MagiC]) 5.20
+216,9 !! 0xD8 !! edit_get_scrollinfo !! (!nolink [MagiC]) 5.20
+217,0 !! 0xD9 !! edit_set_buf       !! (!nolink [MagiC]) 5.20
+217,1 !! 0xD9 !! edit_set_format    !! (!nolink [MagiC]) 5.20
+217,2 !! 0xD9 !! edit_set_colour    !! (!nolink [MagiC]) 5.20
+217,3 !! 0xD9 !! edit_set_font      !! (!nolink [MagiC]) 5.20
+217,4 !! 0xD9 !! edit_set_cursor    !! (!nolink [MagiC]) 5.20
+217,5 !! 0xD9 !! edit_set_pos       !! (!nolink [MagiC]) 5.20
+217,6 !! 0xD9 !! edit_resized       !! (!nolink [MagiC]) 5.20
+217,7 !! 0xD9 !! edit_set_dirty     !! (!nolink [MagiC]) 5.20
+217,9 !! 0xD9 !! edit_scroll        !! (!nolink [MagiC]) 5.20
 !hline
 250 !! 0xFA !! button_click         !! bis (!nolink [XaAES]) v0.963
 251 !! 0xFB !! new_client           !! bis (!nolink [XaAES]) v0.963
@@ -581,43 +585,43 @@ dez !! hex !! Funktionsname !! vorhanden
 260 !! 0x104 !! appl_pipe           !! bis (!nolink [XaAES]) v0.963
 !hline
 1010 !! 0x3F2 !! prop_get           !! FreeGEM, 25.7.1999
-1011 !! 0x3F3 !! prop_put           !! FreeGEM, 25.7.1999
-1012 !! 0x3F4 !! prop_del           !! FreeGEM, 25.7.1999
-1013 !! 0x3F5 !! prop_gui_get       !! FreeGEM3, 22.3.2000
-1014 !! 0x3F6 !! prop_gui_set       !! FreeGEM3, 22.3.2000
-1020 !! 0x3FC !! x_appl_getinfo     !! FreeGEM, 8.8.1999
-1030 !! 0x406 !! xshl_getshell      !! FreeGEM, 3.12.1999
-1031 !! 0x407 !! xshl_setshell      !! FreeGEM, 3.12.1999
+1011 !! 0x3F3 !! prop_put           !! (!nolink [FreeGEM]), 25.7.1999
+1012 !! 0x3F4 !! prop_del           !! (!nolink [FreeGEM]), 25.7.1999
+1013 !! 0x3F5 !! prop_gui_get       !! (!nolink [FreeGEM]), 22.3.2000
+1014 !! 0x3F6 !! prop_gui_set       !! (!nolink [FreeGEM]), 22.3.2000
+1020 !! 0x3FC !! xapp_getinfo       !! (!nolink [FreeGEM]), 8.8.1999
+1030 !! 0x406 !! xshl_getshell      !! (!nolink [FreeGEM]), 3.12.1999
+1031 !! 0x407 !! xshl_setshell      !! (!nolink [FreeGEM]), 3.12.1999
 !hline
 28928 !! 0x7100 !! x_appl_flags     !! Geneva
-28929 !! 0x7101 !! x_appl_font      !! Geneva
-28930 !! 0x7102 !! x_appl_sleep     !! Geneva
-28931 !! 0x7103 !! x_appl_term      !! Geneva
-28944 !! 0x7110 !! x_form_center    !! Geneva
-28945 !! 0x7111 !! x_form_error     !! Geneva
-28946 !! 0x7112 !! x_form_filename  !! Geneva
-28947 !! 0x7113 !! x_form_mouse     !! Geneva
-28960 !! 0x7120 !! x_fsel_input     !! Geneva
-28976 !! 0x7130 !! x_graf_blit      !! Geneva
-28977 !! 0x7131 !! x_graf_rubberbox !! Geneva
-28978 !! 0x7132 !! x_graf_rast2rez  !! Geneva 004
-28992 !! 0x7140 !! x_objc_edit      !! Geneva
-29008 !! 0x7150 !! x_wdial_draw     !! Geneva
-29009 !! 0x7151 !! x_wdial_change   !! Geneva
-29010 !! 0x7152 !! x_wind_tree      !! Geneva
-29011 !! 0x7153 !! x_wind_create    !! Geneva
-29012 !! 0x7154 !! x_wind_calc      !! Geneva
-29024 !! 0x7160 !! x_scrp_get       !! Geneva 004
-29056 !! 0x7180 !! x_settings       !! Geneva
-29057 !! 0x7181 !! x_shel_get       !! Geneva
-29058 !! 0x7182 !! x_shel_put       !! Geneva
-29059 !! 0x7183 !! x_sprintf        !! Geneva
-29060 !! 0x7184 !! x_sscanf         !! Geneva
-29061 !! 0x7185 !! x_help           !! Geneva
-29062 !! 0x7186 !! x_malloc         !! Geneva 004
-29063 !! 0x7187 !! x_mfree          !! Geneva 004
-29064 !! 0x7188 !! x_mshrink        !! Geneva 004
-29065 !! 0x7189 !! x_realloc        !! Geneva 004
+28929 !! 0x7101 !! x_appl_font      !! (!nolink [Geneva
+28930 !! 0x7102 !! x_appl_sleep     !! (!nolink [Geneva])
+28931 !! 0x7103 !! x_appl_term      !! (!nolink [Geneva])
+28944 !! 0x7110 !! x_form_center    !! (!nolink [Geneva])
+28945 !! 0x7111 !! x_form_error     !! (!nolink [Geneva])
+28946 !! 0x7112 !! x_form_filename  !! (!nolink [Geneva])
+28947 !! 0x7113 !! x_form_mouse     !! (!nolink [Geneva])
+28960 !! 0x7120 !! x_fsel_input     !! (!nolink [Geneva])
+28976 !! 0x7130 !! x_graf_blit      !! (!nolink [Geneva])
+28977 !! 0x7131 !! x_graf_rubberbox !! (!nolink [Geneva])
+28978 !! 0x7132 !! x_graf_rast2rez  !! (!nolink [Geneva]) 004
+28992 !! 0x7140 !! x_objc_edit      !! (!nolink [Geneva])
+29008 !! 0x7150 !! x_wdial_draw     !! (!nolink [Geneva])
+29009 !! 0x7151 !! x_wdial_change   !! (!nolink [Geneva])
+29010 !! 0x7152 !! x_wind_tree      !! (!nolink [Geneva])
+29011 !! 0x7153 !! x_wind_create    !! (!nolink [Geneva])
+29012 !! 0x7154 !! x_wind_calc      !! (!nolink [Geneva])
+29024 !! 0x7160 !! x_scrp_get       !! (!nolink [Geneva]) 004
+29056 !! 0x7180 !! x_settings       !! (!nolink [Geneva])
+29057 !! 0x7181 !! x_shel_get       !! (!nolink [Geneva])
+29058 !! 0x7182 !! x_shel_put       !! (!nolink [Geneva])
+29059 !! 0x7183 !! x_sprintf        !! (!nolink [Geneva])
+29060 !! 0x7184 !! x_sscanf         !! (!nolink [Geneva])
+29061 !! 0x7185 !! x_help           !! (!nolink [Geneva])
+29062 !! 0x7186 !! x_malloc         !! (!nolink [Geneva]) 004
+29063 !! 0x7187 !! x_mfree          !! (!nolink [Geneva]) 004
+29064 !! 0x7188 !! x_mshrink        !! (!nolink [Geneva]) 004
+29065 !! 0x7189 !! x_realloc        !! (!nolink [Geneva]) 004
 !hline
 !end_table
 !end_node

--- a/tos/tos_de.ui
+++ b/tos/tos_de.ui
@@ -152,31 +152,48 @@ Part of the (!nolink [GEM]) PTK/SDK 3.13 which finally was rewritten to support
 ANSI C
 compilers.
 
-!begin_verbatim
-GEM/4  DRIVDI.EXE     Only made it to the market as runtime support
-       DRIAES.EXE     for Artline/2, PresTeam/2, Publish it/3 etc.
-                      The VDI will use EMS, if available.
-                      The GEM/3 desktop will not run properly, and
-                      a com shell provided to launch gem/4 apps from
-                      the GEM/3 desktop may crash after repeated use.
+!label GEM/4
+(!B)(!nolink [GEM])/4:(!b)
+Only made it to the market as runtime support for Artline/2, PresTeam/2,
+Publish it/3 etc.
+The VDI will use EMS, if available.
 
-                      Probably the model for DRI's X/GEM for FlexOS,
-                      A 32bit protected mode multitasking system.
-!end_verbatim
+The (!nolink [GEM])/3 desktop will not run properly, and a com shell provided
+to launch gem/4 apps from the (!nolink [GEM])/3 desktop may crash after
+repeated use.
+
+!label GEM/5
+(!B)(!nolink [GEM])/5:(!b)
+Only made it to the market as runtime support for Timeworks Publisher 2.1.
+It had scalable font support using XMS memory, and adds 3D look and feel to
+AES objects.
+
+Both (!nolink [GEM])/4 and (!nolink [GEM])/5 added new VDI and AES calls but their bindings are
+unknown. This proprietary AES 4.0 has support for a new MU_HELP message
+and some calls take an additional parameter for context-sensitive help.
+What these features really do is not known.
+
+!label GEM/XM
+(!B)(!nolink [GEM])/XM:(!b)
+Probably the model for DRI's X/GEM for FlexOS (a 32bit protected mode
+multitasking system). GEM/XM planned to bring support for multitasking
+under DOS but remained unfinished. Latest release is FreeGEM/XM 3.0beta5-je1.
 
 !label ViewMax
-ViewMax/ DR-DOS 5.0: A 'crippled' (!nolink [GEM])/4 kernel, can only be used as
+!label ViewMAX
+(!B)ViewMAX:(!b)
+ViewMAX/1 (DR-DOS 5.0) is a 'crippled' (!nolink [GEM])/4 kernel, can only be used as
 a shell to call (!nolink [GEM]) Applications. Although designed for DR DOS, it will
-run under MS-DOS 3.x and later (minus passwords). To use it with GEM apps you
-must have a GEM/3 installation as well as a Viewmax installation.
+run under MS-DOS 3.x and later (minus passwords). To use it with (!nolink [GEM]) apps you
+must have a (!nolink [GEM])/3 installation as well as a ViewMAX installation.
 This version was written in Lattice C 3.x
 
-ViewMax/ DR-DOS 6.0:  Improved version of the above, but with the
+ViewMAX/2 (DR-DOS 6.0) was an improved version of the above, but with the
 same kernel limitations as the above.
 This version was rewritten in Turbo C2.0 and
 and allows configuration via *.ini file.
 
-
+ViewMAX/3 (DR-DOS 7.0) was never released but beta code is available.
 
 !label Extended GEM
 !label GEM, Extended

--- a/tos/tos_en.ui
+++ b/tos/tos_en.ui
@@ -161,31 +161,48 @@ The last standard retail version shipped. Part of
 the (!nolink [GEM]) PTK/SDK 3.13 which finally was rewritten to support ANSI C
 compilers.
 
-!begin_verbatim
-GEM/4  DRIVDI.EXE     Only made it to the market as runtime support
-       DRIAES.EXE     for Artline/2, PresTeam/2, Publish it/3 etc.
-                      The VDI will use EMS, if available.
-                      The GEM/3 desktop will not run properly, and
-                      a com shell provided to launch gem/4 apps from
-                      the GEM/3 desktop may crash after repeated use.
+!label GEM/4
+(!B)(!nolink [GEM])/4:(!b)
+Only made it to the market as runtime support for Artline/2, PresTeam/2,
+Publish it/3 etc.
+The VDI will use EMS, if available.
 
-                      Probably the model for DRI's X/GEM for FlexOS,
-                      A 32bit protected mode multitasking system.
-!end_verbatim
+The (!nolink [GEM])/3 desktop will not run properly, and a com shell provided
+to launch gem/4 apps from the (!nolink [GEM])/3 desktop may crash after
+repeated use.
+
+!label GEM/5
+(!B)(!nolink [GEM])/5:(!b)
+Only made it to the market as runtime support for Timeworks Publisher 2.1.
+It had scalable font support using XMS memory, and adds 3D look and feel to
+AES objects.
+
+Both (!nolink [GEM])/4 and (!nolink [GEM])/5 added new VDI and AES calls but their bindings are
+unknown. This proprietary AES 4.0 has support for a new MU_HELP message
+and some calls take an additional parameter for context-sensitive help.
+What these features really do is not known.
+
+!label GEM/XM
+(!B)(!nolink [GEM])/XM:(!b)
+Probably the model for DRI's X/GEM for FlexOS (a 32bit protected mode
+multitasking system). GEM/XM planned to bring support for multitasking
+under DOS but remained unfinished. Latest release is FreeGEM/XM 3.0beta5-je1.
 
 !label ViewMax
-ViewMax/ DR-DOS 5.0: A 'crippled' (!nolink [GEM])/4 kernel, can only be used as
+!label ViewMAX
+(!B)ViewMAX:(!b)
+ViewMAX/1 (DR-DOS 5.0) is a 'crippled' (!nolink [GEM])/4 kernel and can only be used as
 a shell to call (!nolink [GEM]) Applications. Although designed for DR DOS, it will
-run under MS-DOS 3.x and later (minus passwords). To use it with GEM apps you
-must have a GEM/3 installation as well as a Viewmax installation.
+run under MS-DOS 3.x and later (minus passwords). To use it with (!nolink [GEM]) apps you
+must have a (!nolink [GEM])/3 installation as well as a ViewMAX installation.
 This version was written in Lattice C 3.x
 
-ViewMax/ DR-DOS 6.0:  Improved version of the above, but with the
+ViewMAX/2 (DR-DOS 6.0) was an improved version of the above, but with the
 same kernel limitations as the above.
 This version was rewritten in Turbo C2.0 and
 and allows configuration via *.ini file.
 
-
+ViewMAX/3 (DR-DOS 7.0) was never released but beta code is available.
 
 !label Extended GEM
 !label GEM, Extended


### PR DESCRIPTION
In tos_en and tos_de:
- Cosmetic changes to GEM/4 (was verbatim style) and ViewMAX (there was no bold style)
- Add GEM/5 and GEM/XM

In aes_f:
- Add !nolink to all links to MagiC (keep just one)
- Add appl_xbvget, proc_shrink
- Add comments to GEM/4 functions and empty the function name column
- Rename GEM Multiapp to GEM/XM, proc_free to proc_mfree and x_appl_getinfo to xapp_getinfo