### PR TITLE
Add deprecated XaAES functions

### DIFF
--- a/gem/aes/aes_f.u
+++ b/gem/aes/aes_f.u
@@ -266,8 +266,10 @@ dec !! hex !! Function name !! Present in
 250 !! 0xFA !! button_click         !! Up to (!nolink [XaAES]) v0.963
 251 !! 0xFB !! new_client           !! Up to (!nolink [XaAES]) v0.963
 252 !! 0xFC !! client_exit          !! Up to (!nolink [XaAES]) v0.963
-253 !! 0xFD !! shutdown             !! Up to (!nolink [XaAES]) v0.963
+253 !! 0xFD !! (!link [shutdown][s_hutdown])             !! Up to (!nolink [XaAES]) v0.963
 254 !! 0xFE !! objc_setscroll       !! Up to (!nolink [XaAES]) v0.963
+255 !! 0xFF !! rregen               !! Up to (!nolink [XaAES]) v0.920
+256 !! 0x100 !! wredraw             !! Up to (!nolink [XaAES]) v0.920
 260 !! 0x104 !! appl_pipe           !! Up to (!nolink [XaAES]) v0.963
 !hline
 1010 !! 0x3F2 !! prop_get           !! FreeGEM, 25.7.1999
@@ -580,8 +582,10 @@ dez !! hex !! Funktionsname !! vorhanden
 250 !! 0xFA !! button_click         !! bis (!nolink [XaAES]) v0.963
 251 !! 0xFB !! new_client           !! bis (!nolink [XaAES]) v0.963
 252 !! 0xFC !! client_exit          !! bis (!nolink [XaAES]) v0.963
-253 !! 0xFD !! shutdown             !! bis (!nolink [XaAES]) v0.963
+253 !! 0xFD !! (!link [shutdown][s_hutdown])             !! bis (!nolink [XaAES]) v0.963
 254 !! 0xFE !! objc_setscroll       !! bis (!nolink [XaAES]) v0.963
+255 !! 0xFF !! rregen               !! bis (!nolink [XaAES]) v0.920
+256 !! 0x100 !! wredraw             !! bis (!nolink [XaAES]) v0.920
 260 !! 0x104 !! appl_pipe           !! bis (!nolink [XaAES]) v0.963
 !hline
 1010 !! 0x3F2 !! prop_get           !! FreeGEM, 25.7.1999

--- a/xaaes/function/appl_pipe.ui
+++ b/xaaes/function/appl_pipe.ui
@@ -1,0 +1,121 @@
+!iflang [english]
+
+!begin_node appl_pipe
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Application pipe(!ldouble) - Obtains the application pipe handle.
+!item [Opcode:]
+260
+!item [Syntax:]
+int16_t appl_pipe ( void );
+
+!item [Description:]
+The call appl_pipe gets the file handle of the client reply pipe. This value is
+also available in global[12] after calling appl_init.
+
+(!B)Note:(!b) This function is deprecated. (!nolink [XaAES]) doesn't rely anymore on pipes
+to exchange (!nolink [AES messages]).
+
+!item [(!nolink [Return]) value:]
+The function returns the file handle of the client reply pipe, or 0 if the pipe is not open.
+
+!item [Availability:]
+Up to (!nolink [XaAES]) v0.963.
+
+!item [Group:]
+XaAES functions
+
+!item [See also:]
+(!link [Binding] [Bindings for appl_pipe]) ~ client_exit ~ new_client
+(!ende_liste)
+
+
+
+!begin_node Bindings for appl_pipe
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t appl_pipe ( void );
+!item [Binding:]
+!begin_verbatim
+int16_t appl_pipe (void)
+{
+   return ( crys_if(260) );
+} 
+!end_verbatim
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! (!nolink [Contents])
+!hline
+control   !! control[0] !! 260   # Function opcode
+control+2 !! control[1] !! 0     # Entry in int_in
+control+4 !! control[2] !! 1     # Entry in int_out
+control+6 !! control[3] !! 0     # Entry in addr_in
+control+8 !! control[4] !! 0     # Entry in addr_out
+int_out !! int_out[0] !! Return value
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node appl_pipe
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Application pipe(!ldouble) - Obtains the application pipe handle.
+!item [AES-Nummer:]
+260
+!item [Deklaration:]
+int16_t appl_pipe ( void );
+
+!item [Beschreibung:]
+The call appl_pipe gets the file handle of the client reply pipe. This value is
+also available in global[12] after calling appl_init.
+
+(!B)Hinweis:(!b) This function is deprecated. (!nolink [XaAES]) doesn't rely anymore on pipes
+to exchange (!nolink [AES messages]).
+
+!item [Ergebnis:]
+The function returns the file handle of the client reply pipe, or 0 if the pipe is not open.
+
+!item [Verf(!uumlaut)gbar:]
+Up to (!nolink [XaAES]) v0.963.
+
+!item [Gruppe:]
+XaAES-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r appl_pipe]) ~ client_exit ~ new_client
+(!ende_liste)
+
+
+
+!begin_node Bindings f(!uumlaut)r appl_pipe
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+int16_t appl_pipe ( void );
+!item [Umsetzung:]
+!begin_verbatim
+int16_t appl_pipe (void)
+{
+   return ( crys_if(260) );
+} 
+!end_verbatim
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Adresse !! Feldelement !! Belegung
+!hline
+control   !! control[0] !! 260   # Opcode der Funktion
+control+2 !! control[1] !! 0     # Eintr(!aumlaut)ge in int_in
+control+4 !! control[2] !! 1     # Eintr(!aumlaut)ge in int_out
+control+6 !! control[3] !! 0     # Eintr(!aumlaut)ge in addr_in
+control+8 !! control[4] !! 0     # Eintr(!aumlaut)ge in addr_out
+int_out !! int_out[0] !! (!nolink [Return])-Wert
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+!endif

--- a/xaaes/function/client_exit.ui
+++ b/xaaes/function/client_exit.ui
@@ -1,0 +1,135 @@
+!iflang [english]
+
+!begin_node client_exit
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Client exit(!ldouble) - Unregisters an (!nolink [AES]) client.
+!item [Opcode:]
+252
+!item [Syntax:]
+void client_exit ( void );
+
+!item [Description:]
+The call client_exit closes the client's reply pipe in response to a
+(!nolink [XA_CLIENT_EXIT]) message. client_exit releases all resources belonging
+to the client (windows, pending messages, menu bar, custom desktop...).
+
+Applications should NEVER send this message to the (!nolink [XaAES]) kernel, it is used
+internally to pass crucial information from the client pid trap handler to the
+(!nolink [XaAES]) kernel.
+
+The (!nolink [XA_CLIENT_EXIT]) message is only sent from (!nolink [XaAES]) itself when a
+client calls appl_exit.
+
+(!B)Note:(!b) This function is deprecated. (!nolink [XaAES]) doesn't rely anymore on pipes
+to exchange (!nolink [AES messages]).
+
+!item [(!nolink [Return]) value:]
+The function does not return a value.
+
+!item [Availability:]
+Up to (!nolink [XaAES]) v0.963.
+
+!item [Group:]
+XaAES functions
+
+!item [See also:]
+(!link [Binding] [Bindings for client_exit]) ~ appl_pipe ~ new_client
+(!ende_liste)
+
+
+
+!begin_node Bindings for client_exit
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void client_exit ( void );
+!item [Binding:]
+!begin_verbatim
+void client_exit (void)
+{
+   crys_if(252);
+} 
+!end_verbatim
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! (!nolink [Contents])
+!hline
+control   !! control[0] !! 252   # Function opcode
+control+2 !! control[1] !! 0     # Entry in int_in
+control+4 !! control[2] !! 0     # Entry in int_out
+control+6 !! control[3] !! 0     # Entry in addr_in
+control+8 !! control[4] !! 0     # Entry in addr_out
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node client_exit
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Client exit(!ldouble) - Unregisters an (!nolink [AES]) client.
+!item [AES-Nummer:]
+252
+!item [Deklaration:]
+void client_exit ( void );
+
+!item [Beschreibung:]
+The call client_exit closes the client's reply pipe in response to a
+(!nolink [XA_CLIENT_EXIT]) message. client_exit releases all resources belonging
+to the client (windows, pending messages, menu bar, custom desktop...).
+
+Applications should NEVER send this message to the (!nolink [XaAES]) kernel, it is used
+internally to pass crucial information from the client pid trap handler to the
+(!nolink [XaAES]) kernel.
+
+The (!nolink [XA_CLIENT_EXIT]) message is only sent from (!nolink [XaAES]) itself when a
+client calls appl_exit.
+
+(!B)Hinweis:(!b) This function is deprecated. (!nolink [XaAES]) doesn't rely anymore on pipes
+to exchange (!nolink [AES messages]).
+
+!item [Ergebnis:]
+The function does not return a value.
+
+!item [Verf(!uumlaut)gbar:]
+Up to (!nolink [XaAES]) v0.963.
+
+!item [Gruppe:]
+XaAES-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r client_exit]) ~ appl_pipe ~ new_client
+(!ende_liste)
+
+
+
+!begin_node Bindings f(!uumlaut)r client_exit
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void client_exit ( void );
+!item [Umsetzung:]
+!begin_verbatim
+void client_exit (void)
+{
+   crys_if (252);
+} 
+!end_verbatim
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Adresse !! Feldelement !! Belegung
+!hline
+control   !! control[0] !! 252   # Opcode der Funktion
+control+2 !! control[1] !! 0     # Eintr(!aumlaut)ge in int_in
+control+4 !! control[2] !! 0     # Eintr(!aumlaut)ge in int_out
+control+6 !! control[3] !! 0     # Eintr(!aumlaut)ge in addr_in
+control+8 !! control[4] !! 0     # Eintr(!aumlaut)ge in addr_out
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+!endif

--- a/xaaes/function/function.u
+++ b/xaaes/function/function.u
@@ -1,0 +1,71 @@
+!iflang [english]
+
+!begin_node XaAES deprecated functions
+!alias XaAES functions
+!html_name xaaes_functions
+!label button_click
+!label objc_setscroll
+!label objc_data
+!label s_hutdown
+
+The following (!nolink [XaAES]) functions were only available in early versions
+and they are now deprecated, including objc_data which is newer but never fully
+implemented.
+
+Opcodes 250, 253 and 254 are assigned to button_click, shutdown and
+objc_setscroll but it looks like they were never used.
+
+!begin_xlist [x objc_setscroll] !compressed
+!item [(!bullet) appl_pipe]      Get handle of the communication pipe
+!item [(!bullet) button_click]   No information available
+!item [(!bullet) client_exit]    Close the communication pipe of a client
+!item [(!bullet) new_client]     Open a communication pipe for a new client
+!item [(!bullet) objc_data]      Get/set data in object trees
+!item [(!bullet) objc_setscroll] No information available
+!item [(!bullet) rregen]         Regenerate rectangle list (debug)
+!item [(!bullet) shutdown]       No information available
+!item [(!bullet) wredraw]        Redraw window (debug)
+!end_xlist
+
+See also: XaAES
+
+!else
+
+!begin_node Veraltete XaAES-Funktionen
+!alias XaAES-Funktionen
+!html_name xaaes_functions
+!label button_click
+!label objc_setscroll
+!label objc_data
+!label s_hutdown
+
+The following (!nolink [XaAES]) functions were only available in early versions
+and they are now deprecated, including objc_data which is newer but never fully
+implemented.
+
+Opcodes 250, 253 and 254 are assigned to button_click, shutdown and
+objc_setscroll but it looks like they were never used.
+
+!begin_xlist [x objc_setscroll] !compressed
+!item [(!bullet) appl_pipe]      Get handle of the communication pipe
+!item [(!bullet) button_click]   No information available
+!item [(!bullet) client_exit]    Close the communication pipe of a client
+!item [(!bullet) new_client]     Open a communication pipe for a new client
+!item [(!bullet) objc_data]      Get/set data in object trees
+!item [(!bullet) objc_setscroll] No information available
+!item [(!bullet) rregen]         Regenerate rectangle list (debug)
+!item [(!bullet) shutdown]       No information available
+!item [(!bullet) wredraw]        Redraw window (debug)
+!end_xlist
+
+See also: XaAES
+
+!endif
+
+!include xaaes/function/appl_pipe.ui
+!include xaaes/function/client_exit.ui
+!include xaaes/function/new_client.ui
+!include xaaes/function/rregen.ui
+!include xaaes/function/wredraw.ui
+
+!end_node

--- a/xaaes/function/new_client.ui
+++ b/xaaes/function/new_client.ui
@@ -1,0 +1,135 @@
+!iflang [english]
+
+!begin_node new_client
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)New client(!ldouble) - (!nolink [Registers]) a new (!nolink [AES]) client.
+!item [Opcode:]
+251
+!item [Syntax:]
+void new_client ( void );
+
+!item [Description:]
+The call new_client opens the client's communication pipe in response to a
+(!nolink [XA_NEW_CLIENT]) message. Applications should NEVER send this message to the
+(!nolink [XaAES]) kernel, it is used internally to pass crucial information from the
+client pid trap handler to the (!nolink [XaAES]) kernel.
+
+The (!nolink [XA_NEW_CLIENT]) message is only sent from (!nolink [XaAES]) itself through
+/pipe/(!nolink [XaAES]).cmd when a client calls appl_init. This triggers the
+creation of a bi-directional command/reply pipe (/pipe/XaClnt.pid, where pid
+is the process ID) that allows internal communication between the client
+and the (!nolink [AES]) server.
+
+(!B)Note:(!b) This function is deprecated. (!nolink [XaAES]) doesn't rely anymore on pipes
+to exchange (!nolink [AES messages]).
+
+!item [(!nolink [Return]) value:]
+The function does not return a value.
+
+!item [Availability:]
+Up to (!nolink [XaAES]) v0.963.
+
+!item [Group:]
+XaAES functions
+
+!item [See also:]
+(!link [Binding] [Bindings for new_client]) ~ appl_pipe ~ client_exit
+(!ende_liste)
+
+
+
+!begin_node Bindings for new_client
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void new_client ( void );
+!item [Binding:]
+!begin_verbatim
+void new_client (void)
+{
+   crys_if(251);
+} 
+!end_verbatim
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! (!nolink [Contents])
+!hline
+control   !! control[0] !! 251   # Function opcode
+control+2 !! control[1] !! 0     # Entry in int_in
+control+4 !! control[2] !! 0     # Entry in int_out
+control+6 !! control[3] !! 0     # Entry in addr_in
+control+8 !! control[4] !! 0     # Entry in addr_out
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node new_client
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)New client(!ldouble) - (!nolink [Registers]) a new (!nolink [AES]) client.
+!item [AES-Nummer:]
+251
+!item [Deklaration:]
+void new_client ( void );
+
+!item [Beschreibung:]
+The call new_client opens the client's communication pipe in response to a
+(!nolink [XA_NEW_CLIENT]) message. Applications should NEVER send this message to the
+(!nolink [XaAES]) kernel, it is used internally to pass crucial information from the
+client pid trap handler to the (!nolink [XaAES]) kernel.
+
+The (!nolink [XA_NEW_CLIENT]) message is only sent from (!nolink [XaAES]) itself through
+/pipe/(!nolink [XaAES]).cmd when a client calls appl_init. This triggers the
+creation of a bi-directional command/reply pipe (/pipe/XaClnt.pid, where pid
+is the process ID) that allows internal communication between the client
+and the (!nolink [AES]) server.
+
+(!B)Hinweis:(!b) This function is deprecated. (!nolink [XaAES]) doesn't rely anymore on pipes
+to exchange (!nolink [AES messages]).
+
+!item [Ergebnis:]
+The function does not return a value.
+
+!item [Verf(!uumlaut)gbar:]
+Up to (!nolink [XaAES]) v0.963.
+
+!item [Gruppe:]
+XaAES-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r new_client]) ~ appl_pipe ~ client_exit
+(!ende_liste)
+
+
+
+!begin_node Bindings f(!uumlaut)r new_client
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void new_client ( void );
+!item [Umsetzung:]
+!begin_verbatim
+void new_client (void)
+{
+   crys_if(251);
+} 
+!end_verbatim
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Adresse !! Feldelement !! Belegung
+!hline
+control   !! control[0] !! 251   # Opcode der Funktion
+control+2 !! control[1] !! 0     # Eintr(!aumlaut)ge in int_in
+control+4 !! control[2] !! 0     # Eintr(!aumlaut)ge in int_out
+control+6 !! control[3] !! 0     # Eintr(!aumlaut)ge in addr_in
+control+8 !! control[4] !! 0     # Eintr(!aumlaut)ge in addr_out
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+!endif

--- a/xaaes/function/rregen.ui
+++ b/xaaes/function/rregen.ui
@@ -1,0 +1,127 @@
+!iflang [english]
+
+!begin_node rregen
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Redraw regenerate(!ldouble) - Regenerates rectangle list for a window.
+!item [Opcode:]
+255
+!item [Syntax:]
+void rregen ( (!nolink [XA_WINDOW]) *w );
+
+!item [Description:]
+The call rregen regenerates the rectangle list for the specified window.
+
+(!I)w(!i) is a pointer to an internal structure that describes the window.
+
+(!B)Note:(!b) This function is for internal use only and allows to call the
+Rectangle List Generator for debugging purposes. rregen is deprecated.
+
+!item [(!nolink [Return]) value:]
+The function does not return a result.
+
+!item [Availability:]
+Up to (!nolink [XaAES]) v0.920.
+
+!item [Group:]
+XaAES functions
+
+!item [See also:]
+(!link [Binding] [Bindings for rregen]) ~ wredraw
+(!ende_liste)
+
+
+
+!begin_node Bindings for rregen
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void rregen ( (!nolink [XA_WINDOW]) *w );
+!item [Binding:]
+!begin_verbatim
+void rregen (XA_WINDOW *w)
+{
+   addr_in[0] = w;
+
+   crys_if(255);
+} 
+!end_verbatim
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! (!nolink [Contents])
+!hline
+control   !! control[0] !! 255   # Function opcode
+control+2 !! control[1] !! 0     # Entry in int_in
+control+4 !! control[2] !! 0     # Entry in int_out
+control+6 !! control[3] !! 1     # Entry in addr_in
+control+8 !! control[4] !! 0     # Entry in addr_out
+addr_in !! addr_in[0] !! w
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node rregen
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Redraw regenerate(!ldouble) - Regenerates rectangle list for a window.
+!item [AES-Nummer:]
+255
+!item [Deklaration:]
+void rregen ( (!nolink [XA_WINDOW]) *w );
+
+!item [Beschreibung:]
+The call rregen regenerates the rectangle list for the specified window.
+
+(!I)w(!i) is a pointer to an internal structure that describes the window.
+
+(!B)Hinweis:(!b) This function is for internal use only and allows to call the
+Rectangle List Generator for debugging purposes. rregen is deprecated.
+
+!item [Ergebnis:]
+The function does not return a result.
+
+!item [Verf(!uumlaut)gbar:]
+Up to (!nolink [XaAES]) v0.920.
+
+!item [Gruppe:]
+XaAES-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r rregen]) ~ wredraw
+(!ende_liste)
+
+
+
+!begin_node Bindings f(!uumlaut)r rregen
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void rregen ( (!nolink [XA_WINDOW]) *w );
+!item [Umsetzung:]
+!begin_verbatim
+void rregen (XA_WINDOWS *w)
+{
+   addr_in[0] = w;
+
+   return ( crys_if(255) );
+} 
+!end_verbatim
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Adresse !! Feldelement !! Belegung
+!hline
+control   !! control[0] !! 255   # Opcode der Funktion
+control+2 !! control[1] !! 0     # Eintr(!aumlaut)ge in int_in
+control+4 !! control[2] !! 0     # Eintr(!aumlaut)ge in int_out
+control+6 !! control[3] !! 1     # Eintr(!aumlaut)ge in addr_in
+control+8 !! control[4] !! 0     # Eintr(!aumlaut)ge in addr_out
+addr_in !! addr_in[0] !! w
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+!endif

--- a/xaaes/function/wredraw.ui
+++ b/xaaes/function/wredraw.ui
@@ -1,0 +1,131 @@
+!iflang [english]
+
+!begin_node wredraw
+(!begin_liste) [Availability]
+!item [Name:]
+(!rdouble)Window redraw(!ldouble) - Redraws a window.
+!item [Opcode:]
+256
+!item [Syntax:]
+void wredraw ( (!nolink [XA_WINDOW]) *w );
+
+!item [Description:]
+The call wredraw redraws a window.
+
+(!I)w(!i) specifies a pointer to an internal structure.
+
+(!B)Note:(!b) This function is for internal use only and allows to redraw a
+whole window by calling a more generic function that takes two extra parameters
+(a user-defined value for debugging purposes, and a clipping rectangle).
+wredraw is deprecated.
+
+!item [(!nolink [Return]) value:]
+The function does not return a result.
+
+!item [Availability:]
+Up to (!nolink [XaAES]) v0.920.
+
+!item [Group:]
+XaAES functions
+
+!item [See also:]
+(!link [Binding] [Bindings for wredraw]) ~ rregen
+(!ende_liste)
+
+
+
+!begin_node Bindings for wredraw
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void wredraw ( (!nolink [XA_WINDOW]) *w );
+!item [Binding:]
+!begin_verbatim
+void wredraw (XA_WINDOW *w)
+{
+   addr_in[0] = w;
+
+   crys_if(256);
+} 
+!end_verbatim
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Address !! Element !! (!nolink [Contents])
+!hline
+control   !! control[0] !! 256   # Function opcode
+control+2 !! control[1] !! 0     # Entry in int_in
+control+4 !! control[2] !! 0     # Entry in int_out
+control+6 !! control[3] !! 1     # Entry in addr_in
+control+8 !! control[4] !! 0     # Entry in addr_out
+addr_in !! addr_in[0] !! w
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+!else
+
+!begin_node wredraw
+(!begin_liste) [Beschreibung]
+!item [Name:]
+(!rdouble)Window redraw(!ldouble) - Redraws a window.
+!item [AES-Nummer:]
+256
+!item [Deklaration:]
+void wredraw ( (!nolink [XA_WINDOW]) *w );
+
+!item [Beschreibung:]
+The call wredraw redraws a window.
+
+(!I)w(!i) specifies a pointer to an internal structure.
+
+(!B)Hinweis:(!b) This function is for internal use only and allows to redraw a
+whole window by calling a more generic function that takes two extra parameters
+(a user-defined value for debugging purposes, and a clipping rectangle).
+wredraw is deprecated.
+
+!item [Ergebnis:]
+The function does not return a result.
+
+!item [Verf(!uumlaut)gbar:]
+Up to (!nolink [XaAES]) v0.920.
+
+!item [Gruppe:]
+XaAES-Funktionen
+
+!item [Querverweis:]
+(!link [Binding] [Bindings f(!uumlaut)r wredraw]) ~ rregen
+(!ende_liste)
+
+
+
+!begin_node Bindings f(!uumlaut)r wredraw
+!ignore_index
+(!begin_liste) [GEM-Arrays]
+!item [C:]
+void wredraw ( (!nolink [XA_WINDOW]) *w );
+!item [Umsetzung:]
+!begin_verbatim
+void wredraw (XA_WINDOW *w)
+{
+   addr_in[0] = w;
+
+   return ( crys_if(256) );
+} 
+!end_verbatim
+!item [GEM-Arrays:]
+!begin_table [l l l]
+Adresse !! Feldelement !! Belegung
+!hline
+control   !! control[0] !! 256   # Opcode der Funktion
+control+2 !! control[1] !! 0     # Eintr(!aumlaut)ge in int_in
+control+4 !! control[2] !! 0     # Eintr(!aumlaut)ge in int_out
+control+6 !! control[3] !! 1     # Eintr(!aumlaut)ge in addr_in
+control+8 !! control[4] !! 0     # Eintr(!aumlaut)ge in addr_out
+addr_in !! addr_in[0] !! w
+!end_table
+(!ende_liste)
+!end_node
+!end_node
+
+!endif

--- a/xaaes/xaaes.u
+++ b/xaaes/xaaes.u
@@ -16,6 +16,8 @@ See also: Toolbar support ~ WF_TOOLBAR ~ WM_TOOLBAR
 
 !end_node
 
+!include function/function.u
+
 !else
 
 !begin_node Toolbar-Support unter XaAES
@@ -32,5 +34,7 @@ ist und zeichnet diese neu.
 Quervweise: Toolbar-Support ~ WF_TOOLBAR ~ WM_TOOLBAR
 
 !end_node
+
+!include function/function.u
 
 !endif


### PR DESCRIPTION
- Update XaAES page by adding deprecated functions
  - Add description of the following functions: appl_pipe, new_client, client_exit
  - Add description of the very old functions with opcodes XA_RREGEN and XA_WREDRAW
  - No info about button_click, shutdown, objc_setscroll (not set in Ktable[], checked in all following versions: beta 6, beta 7, 0.920, 0.963)
  - Set objc_data as deprecated