### PR TITLE
Update matrix xbios extension

### DIFF
--- a/xbios/matrix/matrix.u
+++ b/xbios/matrix/matrix.u
@@ -10,36 +10,43 @@
 
 The driver for the MATRIX graphic card installs some XBIOS functions.
 
-MatGraph - Cxx
+!begin_node MatScreen - Cxx
+!alias xbios(32000)
+!alias xbios(32001)
+!alias xbios(32002)
 
 cxx_info.tos
 
 
-!begin_itemize !compressed
-!item Unknown   = 0x7D00 = 32000
-!item Unknown   = 0x7D01 = 32001
-!item CHECKinst = 0x7D02 = 32002
+!begin_table [l l]
+Function number !! Description
+!hline
+32000 !! Unknown
+32001 !! Unknown
+32002 !! Returns 'CxOk' (0x43784f6b) if the driver is (!nolink [installed])
+!end_table
 
-!item INSTokay	=	0x43784f6b	;	'CxOk'
-!end_itemize
-
-XBRA "M_IN"
+(!link [XBRA ID M_IN][Cookie, M_IN])
+!end_node
 
 
-
-MatGraph - TCxx
+!begin_node MatGraph - TCxx
+!alias xbios(CHECKinst)
+!alias xbios(GETscreen)
+!alias xbios(GETboard)
 
 tcxxinfo.tos
 
-!begin_itemize !compressed
-!item CHECKinst	=	31000
-!item GETscreen	=	31001
-!item GETboard	=	31002
+!begin_table [l l]
+Function number !! Description
+!hline
+CHECKinst (31000) !! Returns INSTokay='TcOk' (0x54634f6b) if the driver is (!nolink [installed])
+GETscreen (31001) !! Returns a pointer to a SCREENparameter structure
+GETboard (31002)  !! Returns a pointer to a BOARDparameter structure
+!end_table
 
-!item INSTokay	=	0x54634f6b	;	'TcOk'
-!end_itemize
-
-XBRA "MTCI"
+(!link [XBRA ID MTCI][Cookie, MTCI]) (!link [Cookie MaTC][Cookie, MaTC])
+!end_node
 
 !end_node
 
@@ -52,36 +59,43 @@ XBRA "MTCI"
 
 The driver for the MATRIX graphic card installs some XBIOS functions.
 
-MatGraph - Cxx
+!begin_node MatScreen - Cxx
+!alias xbios(32000)
+!alias xbios(32001)
+!alias xbios(32002)
 
 cxx_info.tos
 
 
-!begin_itemize !compressed
-!item Unknown   = 0x7D00 = 32000
-!item Unknown   = 0x7D01 = 32001
-!item CHECKinst = 0x7D02 = 32002
+!begin_table [l l]
+Function number !! Description
+!hline
+32000 !! Unknown
+32001 !! Unknown
+32002 !! Returns 'CxOk' (0x43784f6b) if the driver is (!nolink [installed])
+!end_table
 
-!item INSTokay	=	0x43784f6b	;	'CxOk'
-!end_itemize
-
-XBRA "M_IN"
+(!link [XBRA ID M_IN][Cookie, M_IN])
+!end_node
 
 
-
-MatGraph - TCxx
+!begin_node MatGraph - TCxx
+!alias xbios(CHECKinst)
+!alias xbios(GETscreen)
+!alias xbios(GETboard)
 
 tcxxinfo.tos
 
-!begin_itemize !compressed
-!item CHECKinst	=	31000
-!item GETscreen	=	31001
-!item GETboard	=	31002
+!begin_table [l l]
+Function number !! Description
+!hline
+CHECKinst (31000) !! Returns INSTokay='TcOk' (0x54634f6b) if the driver is (!nolink [installed])
+GETscreen (31001) !! Returns a pointer to a SCREENparameter structure
+GETboard (31002)  !! Returns a pointer to a BOARDparameter structure
+!end_table
 
-!item INSTokay	=	0x54634f6b	;	'TcOk'
-!end_itemize
-
-XBRA "MTCI"
+(!link [XBRA ID MTCI][Cookie, MTCI]) (!link [Cookie MaTC][Cookie, MaTC])
+!end_node
 
 !end_node
 

--- a/xbios/xbios_f.u
+++ b/xbios/xbios_f.u
@@ -292,12 +292,12 @@ Dec !! Hex !! Name of function !! TOS !! others
 !hline
 17226 !! 0x434A !! CJar                !! ~    !! Cookie Jar Manager
 !hline
-31000 !! 0x7918 !! CHECKinst           !! ~    !! MATRIX MatGraph - TCxx
-31001 !! 0x7919 !! GETscreen           !! ~    !! MATRIX MatGraph - TCxx
-31002 !! 0x791A !! GETboard            !! ~    !! MATRIX MatGraph - TCxx
-32000 !! 0x7D00 !! Unknown             !! ~    !! MATRIX MatGraph - Cxx
-32001 !! 0x7D01 !! Unknown             !! ~    !! MATRIX MatGraph - Cxx
-32002 !! 0x7D02 !! CHECKinst           !! ~    !! MATRIX MatGraph - Cxx
+31000 !! 0x7918 !! xbios(CHECKinst)    !! ~    !! MATRIX MatGraph - TCxx
+31001 !! 0x7919 !! xbios(GETscreen)    !! ~    !! MATRIX (!nolink [MatGraph - TCxx])
+31002 !! 0x791A !! xbios(GETboard)     !! ~    !! MATRIX (!nolink [MatGraph - TCxx])
+32000 !! 0x7D00 !! xbios(32000)        !! ~    !! MATRIX MatScreen - Cxx
+32001 !! 0x7D01 !! xbios(32001)        !! ~    !! MATRIX (!nolink [MatScreen - Cxx])
+32002 !! 0x7D02 !! xbios(32002)        !! ~    !! MATRIX (!nolink [MatScreen - Cxx])
 !hline
 50698 !! 0xC60A !!  ct60_read_core_temperature  !! ~    !! ct60
 50699 !! 0xC60B !!  ct60_rw_parameter           !! ~    !! ct60
@@ -606,12 +606,12 @@ dez !! hex !! Funktionsname !! TOS !! Sonstiges
 !hline
 17226 !! 0x434A !! CJar                !! ~    !! Cookie Jar Manager
 !hline
-31000 !! 0x7918 !! CHECKinst           !! ~    !! MATRIX MatGraph - TCxx
-31001 !! 0x7919 !! GETscreen           !! ~    !! MATRIX MatGraph - TCxx
-31002 !! 0x791A !! GETboard            !! ~    !! MATRIX MatGraph - TCxx
-32000 !! 0x7D00 !! Unknown             !! ~    !! MATRIX MatGraph - Cxx
-32001 !! 0x7D01 !! Unknown             !! ~    !! MATRIX MatGraph - Cxx
-32002 !! 0x7D02 !! CHECKinst           !! ~    !! MATRIX MatGraph - Cxx
+31000 !! 0x7918 !! xbios(CHECKinst)    !! ~    !! MATRIX MatGraph - TCxx
+31001 !! 0x7919 !! xbios(GETscreen)    !! ~    !! MATRIX (!nolink [MatGraph - TCxx])
+31002 !! 0x791A !! xbios(GETboard)     !! ~    !! MATRIX (!nolink [MatGraph - TCxx])
+32000 !! 0x7D00 !! xbios(32000)        !! ~    !! MATRIX MatScreen - Cxx
+32001 !! 0x7D01 !! xbios(32001)        !! ~    !! MATRIX (!nolink [MatScreen - Cxx])
+32002 !! 0x7D02 !! xbios(32002)        !! ~    !! MATRIX (!nolink [MatScreen - Cxx])
 !hline
 50698 !! 0xC60A !!  ct60_read_core_temperature  !! ~    !! ct60
 50699 !! 0xC60B !!  ct60_rw_parameter           !! ~    !! ct60


### PR DESCRIPTION
- Update page about MATRIX XBIOS extension to add links from the XBIOS function list
- Add links to xbra and cookie
- cxx_info.tos is MatScreen CXX (instead of MatGraph)
