### PR TITLE
XBIOS/VsetScreen: specify that null laddr and paddr will cause screen memory reallocation in Falcon mode

### DIFF
--- a/xbios/bildscrm/vsetscre.ui
+++ b/xbios/bildscrm/vsetscre.ui
@@ -33,9 +33,9 @@ mode !! modecode (see VsetMode)
 A value of -1 here means that the corresponding  
 address or resolution will not be altered.
 
-If both laddr and paddr are null, then screen memory will be reallocated using
-Srealloc and both logical and physical screen addresses will point to the newly
-allocated area.
+If Falcon mode (rez == 3 and mode != -1), if both laddr and paddr are null, then
+screen memory will be reallocated using Srealloc and both logical and physical
+screen addresses will point to the newly allocated area.
 
 (!B)Note:(!b) One should always check whether possible 
 changes were really performed successfully. 

--- a/xbios/bildscrm/vsetscre.ui
+++ b/xbios/bildscrm/vsetscre.ui
@@ -33,6 +33,10 @@ mode !! modecode (see VsetMode)
 A value of -1 here means that the corresponding  
 address or resolution will not be altered.
 
+If both laddr and paddr are null, then screen memory will be reallocated using
+Srealloc and both logical and physical screen addresses will point to the newly
+allocated area.
+
 (!B)Note:(!b) One should always check whether possible 
 changes were really performed successfully. 
 During resolution changes the (!link [VT52 emulator][VT-52 terminal]) is 

--- a/xbios/bildscrm/vsetscre.ui
+++ b/xbios/bildscrm/vsetscre.ui
@@ -33,7 +33,7 @@ mode !! modecode (see VsetMode)
 A value of -1 here means that the corresponding  
 address or resolution will not be altered.
 
-If Falcon mode (rez == 3 and mode != -1), if both laddr and paddr are null, then
+In Falcon mode (rez == 3 and mode != -1), if both laddr and paddr are null, then
 screen memory will be reallocated using Srealloc and both logical and physical
 screen addresses will point to the newly allocated area.
 


### PR DESCRIPTION
That's really what it does (as seen in EmuTOS sources) but this behaviour was not explicit in the documentation.
The Atari Compendium also documents this behaviour.